### PR TITLE
Refactor floating-window layer hook management and raise icon size limits

### DIFF
--- a/ConfigHandlers/MainConfigData.cs
+++ b/ConfigHandlers/MainConfigData.cs
@@ -177,7 +177,7 @@ public class MainConfigData : INotifyPropertyChanged
         get => _floatingWindowIconSize;
         set
         {
-            var clamped = Math.Clamp(value, 8, 30);
+            var clamped = Math.Clamp(value, 15, 50);
             if (clamped == _floatingWindowIconSize) return;
             _floatingWindowIconSize = clamped;
             OnPropertyChanged();

--- a/Services/FloatingWindowService.cs
+++ b/Services/FloatingWindowService.cs
@@ -287,7 +287,7 @@ public class FloatingWindowService
         }
 
         var scale = Math.Clamp(_configHandler.Data.FloatingWindowScale, 0.5, 2.0);
-        var iconSize = Math.Clamp(_configHandler.Data.FloatingWindowIconSize, 8, 30) * scale;
+        var iconSize = Math.Clamp(_configHandler.Data.FloatingWindowIconSize, 15, 50) * scale;
         var textSize = Math.Clamp(_configHandler.Data.FloatingWindowTextSize, 8, 30) * scale;
         var opacity = Math.Clamp(_configHandler.Data.FloatingWindowOpacity, 10, 100);
         var alpha = (byte)Math.Round(255 * (opacity / 100.0));
@@ -779,30 +779,6 @@ public class FloatingWindowService
             _winEventProc = OnWinEvent;
         }
 
-        if (_foregroundHook == IntPtr.Zero)
-        {
-            _foregroundHook = SetWinEventHook(
-                EventSystemForeground,
-                EventSystemForeground,
-                IntPtr.Zero,
-                _winEventProc,
-                0,
-                0,
-                WinEventOutOfContext | WinEventSkipOwnProcess);
-        }
-
-        if (_reorderHook == IntPtr.Zero)
-        {
-            _reorderHook = SetWinEventHook(
-                EventObjectReorder,
-                EventObjectReorder,
-                IntPtr.Zero,
-                _winEventProc,
-                0,
-                0,
-                WinEventOutOfContext | WinEventSkipOwnProcess);
-        }
-
         LayerRecheck50MsTimer.Tick -= OnLayerRecheck50MsTimerTick;
         LayerRecheck50MsTimer.Tick += OnLayerRecheck50MsTimerTick;
         LayerRecheck1MsTimer.Tick -= OnLayerRecheck1MsTimerTick;
@@ -827,8 +803,85 @@ public class FloatingWindowService
     private void RefreshLayerRecheckMode()
     {
         var mode = _configHandler.Data.FloatingWindowLayerRecheckMode;
+        var useReorderHook = mode == 0;
+        var useForegroundHook = mode == 1;
+
+        if (useForegroundHook)
+        {
+            EnsureForegroundHook();
+        }
+        else
+        {
+            RemoveForegroundHook();
+        }
+
+        if (useReorderHook)
+        {
+            EnsureReorderHook();
+        }
+        else
+        {
+            RemoveReorderHook();
+        }
+
         LayerRecheck50MsTimer.IsEnabled = mode == 2;
         LayerRecheck1MsTimer.IsEnabled = mode == 3;
+    }
+
+    private void EnsureForegroundHook()
+    {
+        if (_foregroundHook != IntPtr.Zero || _winEventProc == null)
+        {
+            return;
+        }
+
+        _foregroundHook = SetWinEventHook(
+            EventSystemForeground,
+            EventSystemForeground,
+            IntPtr.Zero,
+            _winEventProc,
+            0,
+            0,
+            WinEventOutOfContext | WinEventSkipOwnProcess);
+    }
+
+    private void EnsureReorderHook()
+    {
+        if (_reorderHook != IntPtr.Zero || _winEventProc == null)
+        {
+            return;
+        }
+
+        _reorderHook = SetWinEventHook(
+            EventObjectReorder,
+            EventObjectReorder,
+            IntPtr.Zero,
+            _winEventProc,
+            0,
+            0,
+            WinEventOutOfContext | WinEventSkipOwnProcess);
+    }
+
+    private void RemoveForegroundHook()
+    {
+        if (_foregroundHook == IntPtr.Zero)
+        {
+            return;
+        }
+
+        UnhookWinEvent(_foregroundHook);
+        _foregroundHook = default;
+    }
+
+    private void RemoveReorderHook()
+    {
+        if (_reorderHook == IntPtr.Zero)
+        {
+            return;
+        }
+
+        UnhookWinEvent(_reorderHook);
+        _reorderHook = default;
     }
 
     private void OnLayerRecheck50MsTimerTick(object? sender, EventArgs e)
@@ -855,18 +908,17 @@ public class FloatingWindowService
             return;
         }
 
+        var mode = _configHandler.Data.FloatingWindowLayerRecheckMode;
+        var shouldRecheck = (@event == EventObjectReorder && mode == 0) ||
+                            (@event == EventSystemForeground && mode == 1);
+        if (!shouldRecheck)
+        {
+            return;
+        }
+
         Dispatcher.UIThread.Post(() =>
         {
-            var mode = _configHandler.Data.FloatingWindowLayerRecheckMode;
-            if (@event == EventSystemForeground && mode == 1)
-            {
-                RecheckWindowLayer();
-            }
-
-            if (@event == EventObjectReorder && mode == 0)
-            {
-                RecheckWindowLayer();
-            }
+            RecheckWindowLayer();
         });
     }
 


### PR DESCRIPTION
### Motivation
- Make layer recheck hook management mode-driven so only the required win-event hooks are installed and removed.
- Reduce unnecessary event callbacks by short-circuiting `OnWinEvent` when the event does not match the configured mode.
- Allow larger floating-window icons by increasing the `FloatingWindowIconSize` allowed range.

### Description
- Increased the clamp range for `FloatingWindowIconSize` from `8..30` to `15..50` in `MainConfigData` and its use in `FloatingWindowService.RefreshWindowButtons`.
- Extracted hook management into explicit helpers: `EnsureForegroundHook`, `EnsureReorderHook`, `RemoveForegroundHook`, and `RemoveReorderHook` and updated `RefreshLayerRecheckMode` to call these based on `FloatingWindowLayerRecheckMode` while keeping timer behavior for modes `2` and `3`.
- Simplified `EnsureLayerRecheckHooks` to only initialize `_winEventProc` and wire the layer recheck timers, and left `RemoveLayerRecheckHooks` to unhook any active hooks.
- Optimized `OnWinEvent` to check the configured mode before dispatching to the UI thread and only call `RecheckWindowLayer` when the incoming event matches the enabled mode.

### Testing
- Built the solution successfully with the changes applied.
- Ran the automated unit test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4299d3efc832b90aca7cac8b2343c)