### PR TITLE
修复：拦截最小化后悬浮窗无响应

### DIFF
--- a/Services/FloatingWindowService.cs
+++ b/Services/FloatingWindowService.cs
@@ -245,10 +245,40 @@ public class FloatingWindowService
 
         if (e.Property == Window.WindowStateProperty && _window.WindowState == WindowState.Minimized)
         {
-            _restoringFromMinimized = true;
-            _window.WindowState = WindowState.Normal;
-            _restoringFromMinimized = false;
+            RestoreWindowFromMinimized();
         }
+    }
+
+    private void RestoreWindowFromMinimized()
+    {
+        if (_window == null || _restoringFromMinimized)
+        {
+            return;
+        }
+
+        _restoringFromMinimized = true;
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            try
+            {
+                if (_window == null)
+                {
+                    return;
+                }
+
+                if (!_window.IsVisible)
+                {
+                    _window.Show();
+                }
+
+                _window.WindowState = WindowState.Normal;
+            }
+            finally
+            {
+                _restoringFromMinimized = false;
+            }
+        }, DispatcherPriority.Background);
     }
 
     private void OnWindowLoaded(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
### Motivation
- 修复在拦截悬浮窗最小化操作时，窗口变为无响应（按钮无法点击、外观更新无效）的异常行为。 
- 问题原因为在 `WindowState` 属性变更回调中同步将窗口状态从最小化设置为 `Normal` 导致重入或在最小化过渡尚未完成时阻塞 UI。 
- 目标是在不阻塞最小化流程的前提下恢复窗口可见/可交互状态并确保状态标志能被可靠重置。 

### Description
- 将原先在 `OnWindowPropertyChanged` 中同步的恢复逻辑替换为调用新方法 `RestoreWindowFromMinimized()`。 
- 在 `RestoreWindowFromMinimized()` 中通过 `Dispatcher.UIThread.Post(..., DispatcherPriority.Background)` 异步在 UI 线程延后执行恢复操作以避免重入问题。 
- 恢复流程先检查并在必要时调用 `Show()` 以确保窗口可见，再设置 `WindowState = WindowState.Normal`，并用 `try/finally` 确保 `_restoringFromMinimized` 标志始终被重置。 

### Testing
- 尝试使用 `dotnet build -v minimal` 进行构建验证但在当前环境因未安装 .NET SDK 报错：`bash: command not found: dotnet`，因此构建/单元测试未能在此环境中运行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43280ea70832ba0641822027a3805)