### PR TITLE
Add BetterSlide carousel component with per-item durations, animations and settings UI

### DIFF
--- a/Controls/Components/BetterSlideComponent.axaml
+++ b/Controls/Components/BetterSlideComponent.axaml
@@ -1,0 +1,127 @@
+<ci:ComponentBase x:Class="SystemTools.Controls.Components.BetterSlideComponent"
+                  x:TypeArguments="settings:BetterSlideComponentSettings"
+                  xmlns="https://github.com/avaloniaui"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:local="clr-namespace:SystemTools.Controls.Components"
+                  xmlns:ci="http://classisland.tech/schemas/xaml/core"
+                  xmlns:settings="clr-namespace:SystemTools.Models.ComponentSettings"
+                  mc:Ignorable="d"
+                  ClipToBounds="False"
+                  AttachedToVisualTree="BetterSlideComponent_OnAttachedToVisualTree"
+                  DetachedFromVisualTree="BetterSlideComponent_OnDetachedFromVisualTree"
+                  d:DesignHeight="450"
+                  d:DesignWidth="800">
+    <ci:ComponentBase.Styles>
+        <Style Selector="ListBoxItem > ContentPresenter#ItemPresenter">
+            <Setter Property="IsVisible" Value="False"/>
+            <Setter Property="Opacity" Value="0"/>
+        </Style>
+
+        <Style Selector="ListBoxItem[IsSelected=True] > ContentPresenter#ItemPresenter">
+            <Setter Property="IsVisible" Value="True"/>
+            <Setter Property="Opacity" Value="1"/>
+            <Setter Property="TranslateTransform.Y" Value="0"/>
+        </Style>
+
+        <Style Selector="ListBox[(local|BetterSlideComponent.IsAnimationEnabled)=True][(local|BetterSlideComponent.AnimationMode)=0] ListBoxItem[IsSelected=True] > ContentPresenter#ItemPresenter">
+            <Style.Animations>
+                <Animation Duration="00:00:00.25" FillMode="Forward">
+                    <KeyFrame Cue="0%">
+                        <Setter Property="Opacity" Value="0"/>
+                        <Setter Property="TranslateTransform.Y" Value="-30"/>
+                    </KeyFrame>
+                    <KeyFrame Cue="100%">
+                        <Setter Property="Opacity" Value="1"/>
+                        <Setter Property="TranslateTransform.Y" Value="0"/>
+                    </KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+
+        <Style Selector="ListBox[(local|BetterSlideComponent.IsAnimationEnabled)=True][(local|BetterSlideComponent.AnimationMode)=1] ListBoxItem[IsSelected=True] > ContentPresenter#ItemPresenter">
+            <Style.Animations>
+                <Animation Duration="00:00:00.3" FillMode="Forward">
+                    <KeyFrame Cue="0%">
+                        <Setter Property="Opacity" Value="0"/>
+                    </KeyFrame>
+                    <KeyFrame Cue="55%">
+                        <Setter Property="Opacity" Value="1"/>
+                    </KeyFrame>
+                    <KeyFrame Cue="80%">
+                        <Setter Property="Opacity" Value="0.4"/>
+                    </KeyFrame>
+                    <KeyFrame Cue="100%">
+                        <Setter Property="Opacity" Value="1"/>
+                    </KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+    </ci:ComponentBase.Styles>
+
+    <Grid x:Name="GridRoot"
+          d:DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:BetterSlideComponent}}"
+          RowDefinitions="*,Auto">
+        <ListBox x:Name="MainListBox"
+                 Grid.Row="0"
+                 Margin="-6 0"
+                 ClipToBounds="False"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ItemsSource="{Binding Settings.Children}"
+                 local:BetterSlideComponent.IsAnimationEnabled="{Binding Settings.IsAnimationEnabled}"
+                 local:BetterSlideComponent.AnimationMode="{Binding Settings.AnimationMode}">
+            <ListBox.Styles>
+                <Style Selector="ScrollViewer">
+                    <Setter Property="VerticalScrollBarVisibility" Value="Disabled" />
+                </Style>
+            </ListBox.Styles>
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <Grid />
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemContainerTheme>
+                <ControlTheme TargetType="ListBoxItem">
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="ListBoxItem">
+                                <ContentPresenter x:Name="ItemPresenter"
+                                                  Content="{Binding $parent[ListBoxItem].Content}"
+                                                  ContentTemplate="{Binding $parent[ListBoxItem].ContentTemplate}">
+                                    <ContentPresenter.RenderTransform>
+                                        <TransformGroup>
+                                            <TranslateTransform Y="0"/>
+                                        </TransformGroup>
+                                    </ContentPresenter.RenderTransform>
+                                </ContentPresenter>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                </ControlTheme>
+            </ListBox.ItemContainerTheme>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <ci:ComponentPresenter IsOnMainWindow="True"
+                                               Settings="{Binding}"
+                                               HidingRules="{Binding HidingRules, Mode=OneWay}"
+                                               HideOnRule="{Binding HideOnRule, Mode=OneWay}"
+                                               VerticalAlignment="Stretch"
+                                               MaxHeight="{DynamicResource IslandContainerHeight}"
+                                               Margin="6 0" />
+                    </Grid>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <ProgressBar Grid.Row="1"
+                     Margin="0 6 0 0"
+                     Height="4"
+                     Minimum="0"
+                     Maximum="100"
+                     IsVisible="{Binding Settings.ShowProgressBar}"
+                     Value="{Binding ProgressPercent}"/>
+    </Grid>
+</ci:ComponentBase>

--- a/Controls/Components/BetterSlideComponent.axaml.cs
+++ b/Controls/Components/BetterSlideComponent.axaml.cs
@@ -1,0 +1,289 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.VisualTree;
+using Avalonia.Threading;
+using ClassIsland.Core.Abstractions.Controls;
+using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Core.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using SystemTools.Models.ComponentSettings;
+
+namespace SystemTools.Controls.Components;
+
+[ContainerComponent]
+[ComponentInfo("E0F5A2B4-4A8D-4B62-A061-2ACF5920B2B3", "更好的轮播容器", "\uE8EE", "支持单组件独立时长、进度条和闪烁动画的轮播容器。")]
+public partial class BetterSlideComponent : ComponentBase<BetterSlideComponentSettings>, INotifyPropertyChanged
+{
+    public new event PropertyChangedEventHandler? PropertyChanged;
+
+    public static readonly AttachedProperty<bool> IsAnimationEnabledProperty =
+        AvaloniaProperty.RegisterAttached<BetterSlideComponent, Control, bool>("IsAnimationEnabled", inherits: true);
+
+    public static readonly AttachedProperty<int> AnimationModeProperty =
+        AvaloniaProperty.RegisterAttached<BetterSlideComponent, Control, int>("AnimationMode", inherits: true);
+
+    public static void SetIsAnimationEnabled(Control obj, bool value) => obj.SetValue(IsAnimationEnabledProperty, value);
+
+    public static bool GetIsAnimationEnabled(Control obj) => obj.GetValue(IsAnimationEnabledProperty);
+
+    public static void SetAnimationMode(Control obj, int value) => obj.SetValue(AnimationModeProperty, value);
+
+    public static int GetAnimationMode(Control obj) => obj.GetValue(AnimationModeProperty);
+
+    private readonly DispatcherTimer _switchTimer = new();
+
+    private readonly DispatcherTimer _progressTimer = new()
+    {
+        Interval = TimeSpan.FromMilliseconds(100)
+    };
+
+    private readonly Random _random = new();
+
+    private readonly Queue<int> _randomPlaylist = [];
+
+    private readonly IRulesetService _rulesetService = IAppHost.GetService<IRulesetService>();
+
+    private DateTime _showingStartAt = DateTime.Now;
+
+    private double _currentDurationSeconds = 5;
+
+    private int _selectedIndex;
+
+    public int SelectedIndex
+    {
+        get => _selectedIndex;
+        set
+        {
+            _selectedIndex = value;
+            MainListBox.SelectedIndex = value;
+        }
+    }
+
+    private int _playingDirection = 1;
+
+    private double _progressPercent;
+
+    public double ProgressPercent
+    {
+        get => _progressPercent;
+        set
+        {
+            _progressPercent = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ProgressPercent)));
+        }
+    }
+
+    public BetterSlideComponent()
+    {
+        InitializeComponent();
+    }
+
+    private void BetterSlideComponent_OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        GridRoot.DataContext = this;
+        Settings.EnsureDurationEntries();
+
+        _switchTimer.Tick += SwitchTimerOnTick;
+        _progressTimer.Tick += ProgressTimerOnTick;
+        Settings.PropertyChanged += SettingsOnPropertyChanged;
+        Settings.Children.CollectionChanged += ChildrenOnCollectionChanged;
+
+        foreach (var item in Settings.ComponentDurations)
+        {
+            item.PropertyChanged += DurationItemOnPropertyChanged;
+        }
+
+        Settings.ComponentDurations.CollectionChanged += ComponentDurationsOnCollectionChanged;
+
+        SelectedIndex = 0;
+        StartCurrentComponentCycle();
+        _switchTimer.Start();
+        _progressTimer.Start();
+    }
+
+    private void BetterSlideComponent_OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        _switchTimer.Stop();
+        _progressTimer.Stop();
+
+        _switchTimer.Tick -= SwitchTimerOnTick;
+        _progressTimer.Tick -= ProgressTimerOnTick;
+        Settings.PropertyChanged -= SettingsOnPropertyChanged;
+        Settings.Children.CollectionChanged -= ChildrenOnCollectionChanged;
+        Settings.ComponentDurations.CollectionChanged -= ComponentDurationsOnCollectionChanged;
+
+        foreach (var item in Settings.ComponentDurations)
+        {
+            item.PropertyChanged -= DurationItemOnPropertyChanged;
+        }
+    }
+
+    private void SettingsOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(BetterSlideComponentSettings.SlideMode))
+        {
+            _randomPlaylist.Clear();
+            _playingDirection = 1;
+        }
+    }
+
+    private void ChildrenOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        Settings.EnsureDurationEntries();
+
+        if (SelectedIndex >= Settings.Children.Count)
+        {
+            SelectedIndex = 0;
+        }
+
+        _randomPlaylist.Clear();
+        StartCurrentComponentCycle();
+    }
+
+    private void ComponentDurationsOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems != null)
+        {
+            foreach (var item in e.NewItems)
+            {
+                if (item is ComponentDurationSetting durationItem)
+                {
+                    durationItem.PropertyChanged += DurationItemOnPropertyChanged;
+                }
+            }
+        }
+
+        if (e.OldItems != null)
+        {
+            foreach (var item in e.OldItems)
+            {
+                if (item is ComponentDurationSetting durationItem)
+                {
+                    durationItem.PropertyChanged -= DurationItemOnPropertyChanged;
+                }
+            }
+        }
+    }
+
+    private void DurationItemOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ComponentDurationSetting.DurationSeconds))
+        {
+            StartCurrentComponentCycle();
+        }
+    }
+
+    private void SwitchTimerOnTick(object? sender, EventArgs e)
+    {
+        if (Settings.Children.Count <= 1)
+        {
+            SelectedIndex = 0;
+            StartCurrentComponentCycle();
+            return;
+        }
+
+        var checkedIndices = new HashSet<int>();
+
+        do
+        {
+            ShowNext();
+
+            if (!checkedIndices.Contains(SelectedIndex)
+                && Settings.Children[SelectedIndex].HideOnRule
+                && _rulesetService.IsRulesetSatisfied(Settings.Children[SelectedIndex].HidingRules))
+            {
+                checkedIndices.Add(SelectedIndex);
+            }
+
+            if (checkedIndices.Count >= Settings.Children.Count)
+            {
+                break;
+            }
+        } while (checkedIndices.Contains(SelectedIndex));
+
+        StartCurrentComponentCycle();
+    }
+
+    private void ShowNext()
+    {
+        switch (Settings.SlideMode)
+        {
+            case 0:
+                SelectedIndex = SelectedIndex + 1 >= Settings.Children.Count ? 0 : SelectedIndex + 1;
+                break;
+            case 1:
+                if (_randomPlaylist.Count == 0)
+                {
+                    CreateRandomPlaylist();
+                }
+
+                SelectedIndex = _randomPlaylist.Dequeue();
+                break;
+            case 2:
+                var target = SelectedIndex + _playingDirection;
+                if (target < 0 || target >= Settings.Children.Count)
+                {
+                    _playingDirection = -_playingDirection;
+                }
+
+                SelectedIndex += _playingDirection;
+                break;
+            default:
+                SelectedIndex = SelectedIndex + 1 >= Settings.Children.Count ? 0 : SelectedIndex + 1;
+                break;
+        }
+    }
+
+    private void CreateRandomPlaylist()
+    {
+        _randomPlaylist.Clear();
+
+        var list = new List<int>();
+        for (var i = 0; i < Settings.Children.Count; i++)
+        {
+            list.Add(i);
+        }
+
+        for (var i = list.Count - 1; i > 0; i--)
+        {
+            var j = _random.Next(i + 1);
+            (list[i], list[j]) = (list[j], list[i]);
+        }
+
+        foreach (var index in list)
+        {
+            _randomPlaylist.Enqueue(index);
+        }
+    }
+
+    private void StartCurrentComponentCycle()
+    {
+        Settings.EnsureDurationEntries();
+
+        _currentDurationSeconds = Settings.GetDurationSecondsFor(SelectedIndex);
+        if (_currentDurationSeconds <= 0)
+        {
+            _currentDurationSeconds = 5;
+        }
+
+        _switchTimer.Interval = TimeSpan.FromSeconds(_currentDurationSeconds);
+        _showingStartAt = DateTime.Now;
+        ProgressPercent = 0;
+    }
+
+    private void ProgressTimerOnTick(object? sender, EventArgs e)
+    {
+        if (_currentDurationSeconds <= 0)
+        {
+            ProgressPercent = 0;
+            return;
+        }
+
+        var elapsed = DateTime.Now - _showingStartAt;
+        var percent = elapsed.TotalSeconds / _currentDurationSeconds * 100;
+        ProgressPercent = Math.Clamp(percent, 0, 100);
+    }
+}

--- a/Controls/Components/BetterSlideSettingsControl.axaml
+++ b/Controls/Components/BetterSlideSettingsControl.axaml
@@ -1,0 +1,78 @@
+<ci:ComponentBase x:Class="SystemTools.Controls.Components.BetterSlideSettingsControl"
+                  x:TypeArguments="settings:BetterSlideComponentSettings"
+                  xmlns="https://github.com/avaloniaui"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:ci="http://classisland.tech/schemas/xaml/core"
+                  xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:local="clr-namespace:SystemTools.Controls.Components"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:settings="clr-namespace:SystemTools.Models.ComponentSettings"
+                  mc:Ignorable="d"
+                  d:DesignHeight="450"
+                  d:DesignWidth="800">
+    <Grid DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:BetterSlideSettingsControl}}">
+        <ScrollViewer>
+            <StackPanel Classes="component-settings-container animated-intro">
+                <controls:SettingsExpander Header="轮换模式"
+                                           Description="设定轮换组件的行为"
+                                           IconSource="{ci:FluentIconSource &#xefcd;}">
+                    <controls:SettingsExpander.Footer>
+                        <ComboBox SelectedIndex="{Binding Settings.SlideMode, Mode=TwoWay}" Width="120">
+                            <ComboBoxItem>循环</ComboBoxItem>
+                            <ComboBoxItem>随机</ComboBoxItem>
+                            <ComboBoxItem>往复</ComboBoxItem>
+                        </ComboBox>
+                    </controls:SettingsExpander.Footer>
+                </controls:SettingsExpander>
+
+                <controls:SettingsExpander Header="启用动画"
+                                           Description="启用后，将在切换组件时播放动画，可选择翻页或闪烁。"
+                                           IconSource="{ci:FluentIconSource &#xedc1;}">
+                    <controls:SettingsExpander.Footer>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <ToggleSwitch IsChecked="{Binding Settings.IsAnimationEnabled, Mode=TwoWay}"/>
+                            <ComboBox Width="120"
+                                      SelectedIndex="{Binding Settings.AnimationMode, Mode=TwoWay}"
+                                      IsEnabled="{Binding Settings.IsAnimationEnabled}">
+                                <ComboBoxItem>翻页动画</ComboBoxItem>
+                                <ComboBoxItem>闪烁动画</ComboBoxItem>
+                            </ComboBox>
+                        </StackPanel>
+                    </controls:SettingsExpander.Footer>
+                </controls:SettingsExpander>
+
+                <controls:SettingsExpander Header="显示进度条"
+                                           Description="启用后，会在显示组件时显示该组件的剩余时长进度。"
+                                           IconSource="{ci:FluentIconSource &#xF3E1;}">
+                    <controls:SettingsExpander.Footer>
+                        <ToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}"/>
+                    </controls:SettingsExpander.Footer>
+                </controls:SettingsExpander>
+
+                <controls:SettingsExpander Header="设置每个组件显示时长"
+                                           Description="自动识别容器内组件，并可分别设置每个组件显示秒数。"
+                                           IconSource="{ci:FluentIconSource &#xEF75;}">
+                    <controls:SettingsExpander.Footer>
+                        <ItemsControl ItemsSource="{Binding Settings.ComponentDurations}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid ColumnDefinitions="*,120" ColumnSpacing="8" Margin="0 4">
+                                        <TextBlock Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Text="{Binding ComponentTitle}"/>
+                                        <NumericUpDown Grid.Column="1"
+                                                       Minimum="0.5"
+                                                       Maximum="600"
+                                                       Increment="0.5"
+                                                       Value="{Binding DurationSeconds, Mode=TwoWay}"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </controls:SettingsExpander.Footer>
+                </controls:SettingsExpander>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</ci:ComponentBase>

--- a/Controls/Components/BetterSlideSettingsControl.axaml.cs
+++ b/Controls/Components/BetterSlideSettingsControl.axaml.cs
@@ -1,0 +1,32 @@
+using ClassIsland.Core.Abstractions.Controls;
+using Avalonia.VisualTree;
+using System.Collections.Specialized;
+using SystemTools.Models.ComponentSettings;
+
+namespace SystemTools.Controls.Components;
+
+public partial class BetterSlideSettingsControl : ComponentBase<BetterSlideComponentSettings>
+{
+    public BetterSlideSettingsControl()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        Settings.EnsureDurationEntries();
+        Settings.Children.CollectionChanged += ChildrenOnCollectionChanged;
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        Settings.Children.CollectionChanged -= ChildrenOnCollectionChanged;
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    private void ChildrenOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        Settings.EnsureDurationEntries();
+    }
+}

--- a/Models/ComponentSettings/BetterSlideComponentSettings.cs
+++ b/Models/ComponentSettings/BetterSlideComponentSettings.cs
@@ -1,0 +1,80 @@
+using ClassIsland.Core.Abstractions.Models;
+using ClassIsland.Core.Models.Components;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.ObjectModel;
+
+namespace SystemTools.Models.ComponentSettings;
+
+public partial class BetterSlideComponentSettings : ObservableObject, IComponentContainerSettings
+{
+    [ObservableProperty] private ObservableCollection<ComponentSettings> _children = new();
+
+    /// <summary>
+    /// 0 - 循环; 1 - 随机; 2 - 往复
+    /// </summary>
+    [ObservableProperty] private int _slideMode = 0;
+
+    [ObservableProperty] private bool _isAnimationEnabled = true;
+
+    /// <summary>
+    /// 0 - 翻页; 1 - 闪烁
+    /// </summary>
+    [ObservableProperty] private int _animationMode = 0;
+
+    [ObservableProperty] private bool _showProgressBar = true;
+
+    [ObservableProperty] private ObservableCollection<ComponentDurationSetting> _componentDurations = [];
+
+    public double GetDurationSecondsFor(int index)
+    {
+        if (index < 0 || index >= ComponentDurations.Count)
+        {
+            return 5;
+        }
+
+        return ComponentDurations[index].DurationSeconds;
+    }
+
+    public void EnsureDurationEntries()
+    {
+        while (ComponentDurations.Count < Children.Count)
+        {
+            ComponentDurations.Add(new ComponentDurationSetting());
+        }
+
+        while (ComponentDurations.Count > Children.Count)
+        {
+            ComponentDurations.RemoveAt(ComponentDurations.Count - 1);
+        }
+
+        for (var i = 0; i < Children.Count; i++)
+        {
+            var child = Children[i];
+            var title = string.IsNullOrWhiteSpace(child.NameCache)
+                ? child.AssociatedComponentInfo.Name
+                : child.NameCache;
+
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                title = $"组件 {i + 1}";
+            }
+
+            ComponentDurations[i].ComponentTitle = title;
+            ComponentDurations[i].ComponentId = child.Id;
+
+            if (ComponentDurations[i].DurationSeconds <= 0)
+            {
+                ComponentDurations[i].DurationSeconds = 5;
+            }
+        }
+    }
+}
+
+public partial class ComponentDurationSetting : ObservableObject
+{
+    [ObservableProperty] private string _componentTitle = string.Empty;
+
+    [ObservableProperty] private string _componentId = string.Empty;
+
+    [ObservableProperty] private double _durationSeconds = 5;
+}

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -298,6 +298,8 @@ public class Plugin : PluginBase
             "SystemTools.ClipboardContent");
         RegisterComponentIfEnabled<LocalQuoteComponent, LocalQuoteSettingsControl>(services, config,
             "SystemTools.LocalQuote");
+        RegisterComponentIfEnabled<BetterSlideComponent, BetterSlideSettingsControl>(services, config,
+            "SystemTools.BetterSlideContainer");
     }
 
     private void RegisterExperimentalFeatures(IServiceCollection services)

--- a/SystemTools.csproj
+++ b/SystemTools.csproj
@@ -10,6 +10,12 @@
       <None Include=".github\workflows\dotnet-build.yml" />
     </ItemGroup>
     
+
+    <ItemGroup>
+        <AvaloniaResource Include="Controls/Components/BetterSlideComponent.axaml" />
+        <AvaloniaResource Include="Controls/Components/BetterSlideSettingsControl.axaml" />
+    </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="ClassIsland.PluginSDK" Version="2.0.0.1" />
         <PackageReference Include="ClassIsland.Core" Version="2.0.0.1" />


### PR DESCRIPTION
### Motivation

- Introduce a more capable carousel container that supports per-component display durations, optional progress bar, and selectable animations and slide modes. 
- Allow authors to configure durations and behavior from the UI and enable skipping components based on existing ruleset conditions. 

### Description

- Add a new Avalonia component `BetterSlideComponent` with corresponding XAML (`Controls/Components/BetterSlideComponent.axaml`) and code-behind (`Controls/Components/BetterSlideComponent.axaml.cs`) that implements slide modes (loop, random, ping-pong), per-item timers, progress tracking, and animation attachments. 
- Add settings model `BetterSlideComponentSettings` and `ComponentDurationSetting` in `Models/ComponentSettings/BetterSlideComponentSettings.cs` to store children, durations, slide mode, animation options and progress bar toggle, with `EnsureDurationEntries` and helper `GetDurationSecondsFor`. 
- Add a settings UI `BetterSlideSettingsControl` with XAML and code-behind (`Controls/Components/BetterSlideSettingsControl.axaml` and `.axaml.cs`) to expose slide mode, animation toggle/mode, progress bar toggle, and per-component duration editing. 
- Register the component in startup via `Plugin.cs` and add the two new `.axaml` resources to the project file (`SystemTools.csproj`). 

### Testing

- Performed an automated build with `dotnet build` which completed successfully. 
- No new automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6cce478a8832b80b383c8d8e25a8e)