### PR TITLE
暴力修复无网络时在 无网络 和 超时 反复横跳的情况

### DIFF
--- a/Controls/Components/NetworkStatusComponent.axaml.cs
+++ b/Controls/Components/NetworkStatusComponent.axaml.cs
@@ -162,9 +162,10 @@ public partial class NetworkStatusComponent : ComponentBase<NetworkStatusSetting
         {
             SetErrorStatus("超时");
         }
+        //因为无网络时会在 无网络 和 超时 反复横跳，所以这里直接把 HttpRequestException 也当做超时处理
         catch (HttpRequestException)
         {
-            SetErrorStatus("无网络");
+            SetErrorStatus("超时");
         }
         catch
         {
@@ -200,11 +201,11 @@ public partial class NetworkStatusComponent : ComponentBase<NetworkStatusSetting
 
             return reply.Status == IPStatus.TimedOut
                 ? IcmpProbeResult.Fail("超时")
-                : IcmpProbeResult.Fail("无网络");
+                : IcmpProbeResult.Fail("超时");
         }
         catch (PingException)
         {
-            return IcmpProbeResult.Fail("无网络");
+            return IcmpProbeResult.Fail("超时");
         }
         catch
         {

--- a/Controls/Components/NetworkStatusComponent.axaml.cs
+++ b/Controls/Components/NetworkStatusComponent.axaml.cs
@@ -162,7 +162,6 @@ public partial class NetworkStatusComponent : ComponentBase<NetworkStatusSetting
         {
             SetErrorStatus("超时");
         }
-        //因为无网络时会在 无网络 和 超时 反复横跳，所以这里直接把 HttpRequestException 也当做超时处理
         catch (HttpRequestException)
         {
             SetErrorStatus("超时");

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ name: SystemTools
 description: 提供多彩而丰富的更多 组件/行动/触发器/实用工具
 entranceAssembly: "SystemTools.dll"
 url: https://github.com/Programmer-MrWang/SystemTools
-version: 2.5.0.102
+version: 2.5.0.103
 apiVersion: 2.0.0.0
 author: Programmer-MrWang
 readme: README.md


### PR DESCRIPTION
### 这个PR更改了以下内容：
将 \Controls\Components\NetworkStatusComponent.axaml.cs 中"无网络"统一替换为”超时“，以避免在无网络时在 无网络 和 超时 之间反复横跳的情况