### PR TITLE
Add background audio action, LocalQuote progress bar, fade animation and adaptive theme detection enhancements

### DIFF
--- a/Actions/BackgroundPlayAudioAction.cs
+++ b/Actions/BackgroundPlayAudioAction.cs
@@ -1,0 +1,65 @@
+using ClassIsland.Core;
+using ClassIsland.Core.Abstractions.Automation;
+using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Core.Attributes;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using SystemTools.Settings;
+
+namespace SystemTools.Actions;
+
+[ActionInfo("SystemTools.BackgroundPlayAudio", "后台播放音频", "\uE189", false)]
+public class BackgroundPlayAudioAction(ILogger<BackgroundPlayAudioAction> logger) : ActionBase<BackgroundPlayAudioSettings>
+{
+    private readonly ILogger<BackgroundPlayAudioAction> _logger = logger;
+
+    protected override async Task OnInvoke()
+    {
+        if (string.IsNullOrWhiteSpace(Settings.AudioFilePath))
+        {
+            _logger.LogWarning("未设置音频文件路径，已跳过播放。");
+            return;
+        }
+
+        if (!File.Exists(Settings.AudioFilePath))
+        {
+            _logger.LogWarning("音频文件不存在：{Path}", Settings.AudioFilePath);
+            return;
+        }
+
+        var audioService = IAppHost.TryGetService<IAudioService>();
+        if (audioService == null)
+        {
+            _logger.LogWarning("未能获取 IAudioService，无法播放音频。");
+            return;
+        }
+
+        try
+        {
+            if (Settings.WaitForPlaybackCompleted)
+            {
+                await audioService.PlayAudioAsync(Settings.AudioFilePath, 1.0f);
+                _logger.LogInformation("音频播放完成：{Path}", Settings.AudioFilePath);
+            }
+            else
+            {
+                _ = audioService.PlayAudioAsync(Settings.AudioFilePath, 1.0f)
+                    .ContinueWith(task =>
+                    {
+                        if (task.Exception != null)
+                        {
+                            _logger.LogError(task.Exception, "后台播放音频任务失败：{Path}", Settings.AudioFilePath);
+                        }
+                    }, TaskScheduler.Default);
+                _logger.LogInformation("已拉起后台音频播放：{Path}", Settings.AudioFilePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "播放音频失败：{Path}", Settings.AudioFilePath);
+            throw;
+        }
+    }
+}

--- a/Actions/BackgroundPlayAudioAction.cs
+++ b/Actions/BackgroundPlayAudioAction.cs
@@ -17,15 +17,16 @@ public class BackgroundPlayAudioAction(ILogger<BackgroundPlayAudioAction> logger
 
     protected override async Task OnInvoke()
     {
-        if (string.IsNullOrWhiteSpace(Settings.AudioFilePath))
+        var normalizedPath = NormalizeAudioPath(Settings.AudioFilePath);
+        if (string.IsNullOrWhiteSpace(normalizedPath))
         {
             _logger.LogWarning("未设置音频文件路径，已跳过播放。");
             return;
         }
 
-        if (!File.Exists(Settings.AudioFilePath))
+        if (!File.Exists(normalizedPath))
         {
-            _logger.LogWarning("音频文件不存在：{Path}", Settings.AudioFilePath);
+            _logger.LogWarning("音频文件不存在：{Path}", normalizedPath);
             return;
         }
 
@@ -40,25 +41,25 @@ public class BackgroundPlayAudioAction(ILogger<BackgroundPlayAudioAction> logger
         {
             if (Settings.WaitForPlaybackCompleted)
             {
-                await PlayAudioFromFileAsync(audioService, Settings.AudioFilePath);
-                _logger.LogInformation("音频播放完成：{Path}", Settings.AudioFilePath);
+                await PlayAudioFromFileAsync(audioService, normalizedPath);
+                _logger.LogInformation("音频播放完成：{Path}", normalizedPath);
             }
             else
             {
-                _ = PlayAudioFromFileAsync(audioService, Settings.AudioFilePath)
+                _ = PlayAudioFromFileAsync(audioService, normalizedPath)
                     .ContinueWith(task =>
                     {
                         if (task.Exception != null)
                         {
-                            _logger.LogError(task.Exception, "后台播放音频任务失败：{Path}", Settings.AudioFilePath);
+                            _logger.LogError(task.Exception, "后台播放音频任务失败：{Path}", normalizedPath);
                         }
                     }, TaskScheduler.Default);
-                _logger.LogInformation("已拉起后台音频播放：{Path}", Settings.AudioFilePath);
+                _logger.LogInformation("已拉起后台音频播放：{Path}", normalizedPath);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "播放音频失败：{Path}", Settings.AudioFilePath);
+            _logger.LogError(ex, "播放音频失败：{Path}", normalizedPath);
             throw;
         }
     }
@@ -67,5 +68,22 @@ public class BackgroundPlayAudioAction(ILogger<BackgroundPlayAudioAction> logger
     {
         await using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
         await audioService.PlayAudioAsync(fs, 1.0f);
+    }
+
+    private static string NormalizeAudioPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return string.Empty;
+        }
+
+        var normalized = Uri.UnescapeDataString(path.Trim());
+        if (OperatingSystem.IsWindows() && normalized.StartsWith("/") &&
+            normalized.Length > 2 && char.IsLetter(normalized[1]) && normalized[2] == ':')
+        {
+            normalized = normalized[1..];
+        }
+
+        return normalized;
     }
 }

--- a/Actions/BackgroundPlayAudioAction.cs
+++ b/Actions/BackgroundPlayAudioAction.cs
@@ -30,6 +30,12 @@ public class BackgroundPlayAudioAction(ILogger<BackgroundPlayAudioAction> logger
             return;
         }
 
+        if (ContainsChinese(normalizedPath))
+        {
+            _logger.LogWarning("后台播放音频不支持中文路径或中文文件名：{Path}", normalizedPath);
+            return;
+        }
+
         var audioService = IAppHost.TryGetService<IAudioService>();
         if (audioService == null)
         {
@@ -85,5 +91,18 @@ public class BackgroundPlayAudioAction(ILogger<BackgroundPlayAudioAction> logger
         }
 
         return normalized;
+    }
+
+    private static bool ContainsChinese(string text)
+    {
+        foreach (var c in text)
+        {
+            if (c is >= '\u4E00' and <= '\u9FFF')
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Actions/BackgroundPlayAudioAction.cs
+++ b/Actions/BackgroundPlayAudioAction.cs
@@ -6,11 +6,12 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using ClassIsland.Shared;
 using SystemTools.Settings;
 
 namespace SystemTools.Actions;
 
-[ActionInfo("SystemTools.BackgroundPlayAudio", "后台播放音频", "\uE189", false)]
+[ActionInfo("SystemTools.BackgroundPlayAudio", "后台播放音频", "\uEBCC", false)]
 public class BackgroundPlayAudioAction(ILogger<BackgroundPlayAudioAction> logger) : ActionBase<BackgroundPlayAudioSettings>
 {
     private readonly ILogger<BackgroundPlayAudioAction> _logger = logger;

--- a/Actions/BackgroundPlayAudioAction.cs
+++ b/Actions/BackgroundPlayAudioAction.cs
@@ -1,7 +1,7 @@
-using ClassIsland.Core;
 using ClassIsland.Core.Abstractions.Automation;
 using ClassIsland.Core.Abstractions.Services;
 using ClassIsland.Core.Attributes;
+using ClassIsland.Shared;
 using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
@@ -40,12 +40,12 @@ public class BackgroundPlayAudioAction(ILogger<BackgroundPlayAudioAction> logger
         {
             if (Settings.WaitForPlaybackCompleted)
             {
-                await audioService.PlayAudioAsync(Settings.AudioFilePath, 1.0f);
+                await PlayAudioFromFileAsync(audioService, Settings.AudioFilePath);
                 _logger.LogInformation("音频播放完成：{Path}", Settings.AudioFilePath);
             }
             else
             {
-                _ = audioService.PlayAudioAsync(Settings.AudioFilePath, 1.0f)
+                _ = PlayAudioFromFileAsync(audioService, Settings.AudioFilePath)
                     .ContinueWith(task =>
                     {
                         if (task.Exception != null)
@@ -61,5 +61,11 @@ public class BackgroundPlayAudioAction(ILogger<BackgroundPlayAudioAction> logger
             _logger.LogError(ex, "播放音频失败：{Path}", Settings.AudioFilePath);
             throw;
         }
+    }
+
+    private static async Task PlayAudioFromFileAsync(IAudioService audioService, string filePath)
+    {
+        await using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        await audioService.PlayAudioAsync(fs, 1.0f);
     }
 }

--- a/ConfigHandlers/MainConfigData.cs
+++ b/ConfigHandlers/MainConfigData.cs
@@ -101,6 +101,20 @@ public class MainConfigData : INotifyPropertyChanged
         }
     }
 
+    bool _autoOpenUsbDriveOnInsert;
+
+    [JsonPropertyName("autoOpenUsbDriveOnInsert")]
+    public bool AutoOpenUsbDriveOnInsert
+    {
+        get => _autoOpenUsbDriveOnInsert;
+        set
+        {
+            if (value == _autoOpenUsbDriveOnInsert) return;
+            _autoOpenUsbDriveOnInsert = value;
+            OnPropertyChanged();
+        }
+    }
+
 
     bool _autoHideMainWindowWhenOccluded;
 

--- a/Controls/BackgroundPlayAudioSettingsControl.cs
+++ b/Controls/BackgroundPlayAudioSettingsControl.cs
@@ -96,7 +96,7 @@ public class BackgroundPlayAudioSettingsControl : ActionSettingsControlBase<Back
             var result = await topLevel.StorageProvider.OpenFilePickerAsync(options);
             if (result != null && result.Count > 0)
             {
-                Settings.AudioFilePath = result[0].Path.LocalPath;
+                Settings.AudioFilePath = NormalizePathForWindows(result[0].Path.LocalPath);
                 _audioPathBox.Text = Settings.AudioFilePath;
             }
         }
@@ -105,5 +105,22 @@ public class BackgroundPlayAudioSettingsControl : ActionSettingsControlBase<Back
             var logger = IAppHost.TryGetService<ILogger<BackgroundPlayAudioSettingsControl>>();
             logger?.LogError(ex, "选择音频文件失败");
         }
+    }
+
+    private static string NormalizePathForWindows(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return path;
+        }
+
+        var normalized = Uri.UnescapeDataString(path);
+        if (OperatingSystem.IsWindows() && normalized.StartsWith("/") &&
+            normalized.Length > 2 && char.IsLetter(normalized[1]) && normalized[2] == ':')
+        {
+            normalized = normalized[1..];
+        }
+
+        return normalized;
     }
 }

--- a/Controls/BackgroundPlayAudioSettingsControl.cs
+++ b/Controls/BackgroundPlayAudioSettingsControl.cs
@@ -1,0 +1,109 @@
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using ClassIsland.Core.Abstractions.Controls;
+using ClassIsland.Shared;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+using SystemTools.Settings;
+
+namespace SystemTools.Controls;
+
+public class BackgroundPlayAudioSettingsControl : ActionSettingsControlBase<BackgroundPlayAudioSettings>
+{
+    private readonly TextBox _audioPathBox;
+    private readonly CheckBox _waitForCompletedCheckBox;
+
+    public BackgroundPlayAudioSettingsControl()
+    {
+        var panel = new StackPanel { Spacing = 10, Margin = new(10) };
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = "后台播放音频",
+            FontWeight = Avalonia.Media.FontWeight.Bold,
+            FontSize = 14
+        });
+
+        var pathPanel = new StackPanel
+        {
+            Orientation = Avalonia.Layout.Orientation.Horizontal,
+            Spacing = 10
+        };
+
+        _audioPathBox = new TextBox
+        {
+            Watermark = "点击“浏览...”选择音频文件",
+            Width = 320,
+            IsReadOnly = true
+        };
+        pathPanel.Children.Add(_audioPathBox);
+
+        var browseButton = new Button
+        {
+            Content = "浏览...",
+            Width = 80
+        };
+        browseButton.Click += async (_, _) => await BrowseAudioFileAsync();
+        pathPanel.Children.Add(browseButton);
+
+        panel.Children.Add(pathPanel);
+
+        _waitForCompletedCheckBox = new CheckBox
+        {
+            Content = "播放后等待播放完成",
+            IsChecked = false
+        };
+        _waitForCompletedCheckBox.IsCheckedChanged += (_, _) =>
+        {
+            Settings.WaitForPlaybackCompleted = _waitForCompletedCheckBox.IsChecked == true;
+        };
+        panel.Children.Add(_waitForCompletedCheckBox);
+
+        Content = panel;
+    }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        _audioPathBox.Text = Settings.AudioFilePath;
+        _waitForCompletedCheckBox.IsChecked = Settings.WaitForPlaybackCompleted;
+    }
+
+    private async Task BrowseAudioFileAsync()
+    {
+        try
+        {
+            var topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel == null)
+            {
+                var logger = IAppHost.TryGetService<ILogger<BackgroundPlayAudioSettingsControl>>();
+                logger?.LogWarning("无法获取 TopLevel");
+                return;
+            }
+
+            var options = new FilePickerOpenOptions
+            {
+                Title = "选择音频文件",
+                AllowMultiple = false,
+                FileTypeFilter =
+                [
+                    new FilePickerFileType("音频文件") { Patterns = ["*.mp3", "*.wav", "*.flac", "*.ogg", "*.m4a", "*.aac"] },
+                    new FilePickerFileType("所有文件") { Patterns = ["*"] }
+                ]
+            };
+
+            var result = await topLevel.StorageProvider.OpenFilePickerAsync(options);
+            if (result != null && result.Count > 0)
+            {
+                Settings.AudioFilePath = result[0].Path.LocalPath;
+                _audioPathBox.Text = Settings.AudioFilePath;
+            }
+        }
+        catch (Exception ex)
+        {
+            var logger = IAppHost.TryGetService<ILogger<BackgroundPlayAudioSettingsControl>>();
+            logger?.LogError(ex, "选择音频文件失败");
+        }
+    }
+}

--- a/Controls/BackgroundPlayAudioSettingsControl.cs
+++ b/Controls/BackgroundPlayAudioSettingsControl.cs
@@ -13,6 +13,7 @@ public class BackgroundPlayAudioSettingsControl : ActionSettingsControlBase<Back
 {
     private readonly TextBox _audioPathBox;
     private readonly CheckBox _waitForCompletedCheckBox;
+    private readonly TextBlock _validationHintTextBlock;
 
     public BackgroundPlayAudioSettingsControl()
     {
@@ -48,6 +49,14 @@ public class BackgroundPlayAudioSettingsControl : ActionSettingsControlBase<Back
         pathPanel.Children.Add(browseButton);
 
         panel.Children.Add(pathPanel);
+
+        _validationHintTextBlock = new TextBlock
+        {
+            Text = "提示：不允许使用中文路径或中文文件名。",
+            Foreground = Avalonia.Media.Brushes.OrangeRed,
+            FontSize = 12
+        };
+        panel.Children.Add(_validationHintTextBlock);
 
         _waitForCompletedCheckBox = new CheckBox
         {
@@ -96,8 +105,17 @@ public class BackgroundPlayAudioSettingsControl : ActionSettingsControlBase<Back
             var result = await topLevel.StorageProvider.OpenFilePickerAsync(options);
             if (result != null && result.Count > 0)
             {
-                Settings.AudioFilePath = NormalizePathForWindows(result[0].Path.LocalPath);
-                _audioPathBox.Text = Settings.AudioFilePath;
+                var normalizedPath = NormalizePathForWindows(result[0].Path.LocalPath);
+                if (ContainsChinese(normalizedPath))
+                {
+                    var logger = IAppHost.TryGetService<ILogger<BackgroundPlayAudioSettingsControl>>();
+                    logger?.LogWarning("后台播放音频不支持中文路径或中文文件名：{Path}", normalizedPath);
+                    _audioPathBox.Text = "不支持中文路径或中文文件名，请重新选择。";
+                    return;
+                }
+
+                Settings.AudioFilePath = normalizedPath;
+                _audioPathBox.Text = normalizedPath;
             }
         }
         catch (Exception ex)
@@ -122,5 +140,18 @@ public class BackgroundPlayAudioSettingsControl : ActionSettingsControlBase<Back
         }
 
         return normalized;
+    }
+
+    private static bool ContainsChinese(string text)
+    {
+        foreach (var c in text)
+        {
+            if (c is >= '\u4E00' and <= '\u9FFF')
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Controls/Components/BetterCarouselContainerComponent.axaml.cs
+++ b/Controls/Components/BetterCarouselContainerComponent.axaml.cs
@@ -31,6 +31,8 @@ public partial class BetterCarouselContainerComponent : ComponentBase<BetterCaro
     private Animation? _slideOutAnimation;
     private Animation? _flashInAnimation;
     private Animation? _flashOutAnimation;
+    private Animation? _fadeInAnimation;
+    private Animation? _fadeOutAnimation;
 
     private int _selectedIndex;
     private int _playDirection = 1;
@@ -212,6 +214,46 @@ public partial class BetterCarouselContainerComponent : ComponentBase<BetterCaro
                 }
             }
         };
+
+        _fadeInAnimation = new Animation
+        {
+            Duration = TimeSpan.FromMilliseconds(250),
+            FillMode = FillMode.Forward,
+            Easing = new QuadraticEaseOut(),
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0),
+                    Setters = { new Setter(Visual.OpacityProperty, 0d) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1),
+                    Setters = { new Setter(Visual.OpacityProperty, 1d) }
+                }
+            }
+        };
+
+        _fadeOutAnimation = new Animation
+        {
+            Duration = TimeSpan.FromMilliseconds(200),
+            FillMode = FillMode.Forward,
+            Easing = new QuadraticEaseIn(),
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0),
+                    Setters = { new Setter(Visual.OpacityProperty, 1d) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1),
+                    Setters = { new Setter(Visual.OpacityProperty, 0d) }
+                }
+            }
+        };
     }
 
     private async Task AnimateTransitionAsync(int fromIndex, int toIndex)
@@ -230,9 +272,12 @@ public partial class BetterCarouselContainerComponent : ComponentBase<BetterCaro
                 fromItem.RenderTransform = new TranslateTransform();
             }
 
-            var outAnimation = Settings.AnimationStyle == BetterCarouselAnimationStyle.Flash 
-                ? _flashOutAnimation 
-                : _slideOutAnimation;
+            var outAnimation = Settings.AnimationStyle switch
+            {
+                BetterCarouselAnimationStyle.Flash => _flashOutAnimation,
+                BetterCarouselAnimationStyle.Fade => _fadeOutAnimation,
+                _ => _slideOutAnimation
+            };
             
             if (outAnimation != null)
             {
@@ -255,9 +300,12 @@ public partial class BetterCarouselContainerComponent : ComponentBase<BetterCaro
             toItem.Opacity = 0;
             toItem.IsVisible = true;
 
-            var inAnimation = Settings.AnimationStyle == BetterCarouselAnimationStyle.Flash 
-                ? _flashInAnimation 
-                : _slideInAnimation;
+            var inAnimation = Settings.AnimationStyle switch
+            {
+                BetterCarouselAnimationStyle.Flash => _flashInAnimation,
+                BetterCarouselAnimationStyle.Fade => _fadeInAnimation,
+                _ => _slideInAnimation
+            };
             
             if (inAnimation != null)
             {

--- a/Controls/Components/LocalQuoteComponent.axaml
+++ b/Controls/Components/LocalQuoteComponent.axaml
@@ -15,6 +15,14 @@
     mc:Ignorable="d">
     <Grid DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:LocalQuoteComponent}}"
           ClipToBounds="True">
+        <ProgressBar VerticalAlignment="Top"
+                     HorizontalAlignment="Stretch"
+                     Height="4"
+                     Minimum="0"
+                     Maximum="100"
+                     IsVisible="{Binding ShowTopProgressBar}"
+                     Value="{Binding CurrentProgressPercent}" />
+
         <TextBlock x:Name="QuoteTextBlock"
                    Text="{Binding CurrentQuote}"
                    TextWrapping="NoWrap"
@@ -24,5 +32,13 @@
                 <TranslateTransform Y="0" />
             </TextBlock.RenderTransform>
         </TextBlock>
+
+        <ProgressBar VerticalAlignment="Bottom"
+                     HorizontalAlignment="Stretch"
+                     Height="4"
+                     Minimum="0"
+                     Maximum="100"
+                     IsVisible="{Binding ShowBottomProgressBar}"
+                     Value="{Binding CurrentProgressPercent}" />
     </Grid>
 </ci:ComponentBase>

--- a/Controls/Components/LocalQuoteComponent.axaml.cs
+++ b/Controls/Components/LocalQuoteComponent.axaml.cs
@@ -30,6 +30,7 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
     private const double SwapMotionOffset = 20;
 
     private readonly DispatcherTimer _carouselTimer;
+    private readonly DispatcherTimer _progressTimer;
     private readonly List<string> _quotes = [];
     private readonly Animation _swapOutAnimation;
     private readonly Animation _swapInAnimation;
@@ -37,6 +38,8 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
     private string _loadedPath = string.Empty;
     private bool _isAnimating;
     private string _currentQuote = "（请先在组件设置中选择 txt 文件）";
+    private DateTime _displayStartedAt = DateTime.UtcNow;
+    private double _currentCycleDurationSeconds = 6;
 
     public string CurrentQuote
     {
@@ -49,6 +52,10 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
     }
 
     public new event PropertyChangedEventHandler? PropertyChanged;
+
+    public double CurrentProgressPercent { get; private set; }
+    public bool ShowTopProgressBar => Settings.ShowProgressBar && Settings.ProgressBarPosition == LocalQuoteProgressBarPosition.Top;
+    public bool ShowBottomProgressBar => Settings.ShowProgressBar && Settings.ProgressBarPosition == LocalQuoteProgressBarPosition.Bottom;
 
     protected virtual void OnPropertyChanged(string propertyName)
     {
@@ -67,6 +74,8 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
 
         _carouselTimer = new DispatcherTimer();
         _carouselTimer.Tick += OnCarouselTicked;
+        _progressTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(100) };
+        _progressTimer.Tick += (_, _) => UpdateProgressState();
 
         _swapOutAnimation = new Animation
         {
@@ -140,6 +149,7 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
     {
         Settings.PropertyChanged -= OnSettingsPropertyChanged;
         _carouselTimer.Stop();
+        _progressTimer.Stop();
     }
 
     private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -147,6 +157,13 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         if (e.PropertyName == nameof(Settings.CarouselIntervalSeconds))
         {
             RefreshTimerInterval();
+            return;
+        }
+
+        if (e.PropertyName is nameof(Settings.ShowProgressBar) or nameof(Settings.ProgressBarPosition))
+        {
+            OnPropertyChanged(nameof(ShowTopProgressBar));
+            OnPropertyChanged(nameof(ShowBottomProgressBar));
             return;
         }
 
@@ -203,7 +220,9 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         }
 
         _carouselTimer.Interval = TimeSpan.FromSeconds(initialDelay);
+        RestartProgressCycle(initialDelay);
         _carouselTimer.Start();
+        _progressTimer.Start();
     }
 
     private void OnCarouselTicked(object? sender, EventArgs e)
@@ -232,6 +251,7 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
     {
         var interval = Math.Clamp(Settings.CarouselIntervalSeconds, 1, 8000);
         _carouselTimer.Interval = TimeSpan.FromSeconds(interval);
+        RestartProgressCycle(interval);
     }
 
     private void LoadQuotesFromFile(string path, bool showFirstQuote)
@@ -307,6 +327,7 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         {
             ResetVisualState();
             CurrentQuote = next;
+            RestartProgressCycle(_carouselTimer.Interval.TotalSeconds);
             return;
         }
 
@@ -316,11 +337,13 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
             await _swapOutAnimation.RunAsync(QuoteTextBlock);
             CurrentQuote = next;
             await _swapInAnimation.RunAsync(QuoteTextBlock);
+            RestartProgressCycle(_carouselTimer.Interval.TotalSeconds);
         }
         catch
         {
             CurrentQuote = next;
             ResetVisualState();
+            RestartProgressCycle(_carouselTimer.Interval.TotalSeconds);
         }
         finally
         {
@@ -340,5 +363,36 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         {
             QuoteTextBlock.RenderTransform = new TranslateTransform();
         }
+    }
+
+    private void RestartProgressCycle(double durationSeconds)
+    {
+        _currentCycleDurationSeconds = Math.Max(1, durationSeconds);
+        _displayStartedAt = DateTime.UtcNow;
+        UpdateProgressState();
+    }
+
+    private void UpdateProgressState()
+    {
+        if (_quotes.Count == 0 || !Settings.ShowProgressBar)
+        {
+            SetProgress(0);
+            return;
+        }
+
+        var elapsed = (DateTime.UtcNow - _displayStartedAt).TotalSeconds;
+        var ratio = Math.Clamp(elapsed / _currentCycleDurationSeconds, 0, 1);
+        SetProgress(ratio * 100);
+    }
+
+    private void SetProgress(double progress)
+    {
+        if (Math.Abs(CurrentProgressPercent - progress) < 0.1)
+        {
+            return;
+        }
+
+        CurrentProgressPercent = progress;
+        OnPropertyChanged(nameof(CurrentProgressPercent));
     }
 }

--- a/Controls/Components/LocalQuoteComponent.axaml.cs
+++ b/Controls/Components/LocalQuoteComponent.axaml.cs
@@ -157,6 +157,7 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         if (e.PropertyName == nameof(Settings.CarouselIntervalSeconds))
         {
             RefreshTimerInterval();
+            EnsureTimersForQuoteState();
             return;
         }
 
@@ -170,6 +171,7 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         if (e.PropertyName == nameof(Settings.QuotesFilePath))
         {
             LoadQuotesFromFile(Settings.QuotesFilePath, showFirstQuote: true);
+            EnsureTimersForQuoteState();
         }
     }
 
@@ -263,12 +265,16 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
 
         if (string.IsNullOrWhiteSpace(path))
         {
+            _carouselTimer.Stop();
+            _progressTimer.Stop();
             CurrentQuote = "（请先在组件设置中选择 txt 文件）";
             return;
         }
 
         if (!File.Exists(path))
         {
+            _carouselTimer.Stop();
+            _progressTimer.Stop();
             CurrentQuote = "（txt 文件不存在）";
             return;
         }
@@ -291,6 +297,8 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
 
             if (_quotes.Count == 0)
             {
+                _carouselTimer.Stop();
+                _progressTimer.Stop();
                 CurrentQuote = "（文件中没有可显示内容）";
                 return;
             }
@@ -302,6 +310,8 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         }
         catch
         {
+            _carouselTimer.Stop();
+            _progressTimer.Stop();
             CurrentQuote = "（读取 txt 文件失败）";
         }
     }
@@ -395,5 +405,28 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
 
         CurrentProgressPercent = progress;
         OnPropertyChanged(nameof(CurrentProgressPercent));
+    }
+
+    private void EnsureTimersForQuoteState()
+    {
+        if (_quotes.Count == 0)
+        {
+            _carouselTimer.Stop();
+            _progressTimer.Stop();
+            return;
+        }
+
+        if (!_carouselTimer.IsEnabled)
+        {
+            var interval = Math.Clamp(Settings.CarouselIntervalSeconds, 1, 8000);
+            _carouselTimer.Interval = TimeSpan.FromSeconds(interval);
+            RestartProgressCycle(interval);
+            _carouselTimer.Start();
+        }
+
+        if (!_progressTimer.IsEnabled)
+        {
+            _progressTimer.Start();
+        }
     }
 }

--- a/Controls/Components/LocalQuoteComponent.axaml.cs
+++ b/Controls/Components/LocalQuoteComponent.axaml.cs
@@ -313,6 +313,10 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
             return;
         }
 
+        // 进度条语义为“距离下一次切换开始的剩余时间”，
+        // 因此需要在当前轮换开始时立即重置，而不是等动画播放完成后再重置。
+        RestartProgressCycle(_carouselTimer.Interval.TotalSeconds);
+
         _currentIndex = (_currentIndex + 1) % _quotes.Count;
         var next = _quotes[_currentIndex];
 
@@ -327,7 +331,6 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         {
             ResetVisualState();
             CurrentQuote = next;
-            RestartProgressCycle(_carouselTimer.Interval.TotalSeconds);
             return;
         }
 
@@ -337,13 +340,11 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
             await _swapOutAnimation.RunAsync(QuoteTextBlock);
             CurrentQuote = next;
             await _swapInAnimation.RunAsync(QuoteTextBlock);
-            RestartProgressCycle(_carouselTimer.Interval.TotalSeconds);
         }
         catch
         {
             CurrentQuote = next;
             ResetVisualState();
-            RestartProgressCycle(_carouselTimer.Interval.TotalSeconds);
         }
         finally
         {

--- a/Controls/Components/LocalQuoteSettingsControl.axaml
+++ b/Controls/Components/LocalQuoteSettingsControl.axaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ci="http://classisland.tech/schemas/xaml/core"
     xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+    xmlns:converters="clr-namespace:SystemTools.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:SystemTools.Controls.Components"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -12,6 +13,9 @@
     d:DesignWidth="800"
     x:TypeArguments="settings:LocalQuoteSettings"
     mc:Ignorable="d">
+    <ci:ComponentBase.Resources>
+        <converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
+    </ci:ComponentBase.Resources>
     <Grid DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:LocalQuoteSettingsControl}}">
         <ScrollViewer>
             <StackPanel>
@@ -58,6 +62,27 @@
                     IconSource="{ci:FluentIconSource &#xF35B;}">
                     <controls:SettingsExpander.Footer>
                         <ToggleSwitch IsChecked="{Binding Settings.IsPersistenceEnabled, Mode=TwoWay}" />
+                    </controls:SettingsExpander.Footer>
+                </controls:SettingsExpander>
+
+                <controls:SettingsExpander
+                    Header="显示进度条"
+                    Description="显示当前句子剩余显示时长的进度条"
+                    IconSource="{ci:FluentIconSource &#xE093;}">
+                    <controls:SettingsExpander.Footer>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <ToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}" />
+                            <ComboBox Width="140"
+                                      IsVisible="{Binding Settings.ShowProgressBar}"
+                                      SelectedItem="{Binding Settings.ProgressBarPosition, Mode=TwoWay}"
+                                      ItemsSource="{Binding ProgressBarPositions}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
                     </controls:SettingsExpander.Footer>
                 </controls:SettingsExpander>
 

--- a/Controls/Components/LocalQuoteSettingsControl.axaml.cs
+++ b/Controls/Components/LocalQuoteSettingsControl.axaml.cs
@@ -8,6 +8,8 @@ namespace SystemTools.Controls.Components;
 
 public partial class LocalQuoteSettingsControl : ComponentBase<LocalQuoteSettings>
 {
+    public Array ProgressBarPositions { get; } = Enum.GetValues(typeof(LocalQuoteProgressBarPosition));
+
     public LocalQuoteSettingsControl()
     {
         InitializeComponent();

--- a/Models/ComponentSettings/BetterCarouselContainerSettings.cs
+++ b/Models/ComponentSettings/BetterCarouselContainerSettings.cs
@@ -26,7 +26,10 @@ public enum BetterCarouselAnimationStyle
     Slide = 0,
 
     [Description("闪烁")]
-    Flash = 1
+    Flash = 1,
+
+    [Description("渐入渐出")]
+    Fade = 2
 }
 
 public enum BetterCarouselProgressBarPosition

--- a/Models/ComponentSettings/LocalQuoteSettings.cs
+++ b/Models/ComponentSettings/LocalQuoteSettings.cs
@@ -1,7 +1,16 @@
 using System;
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SystemTools.Models.ComponentSettings;
+
+public enum LocalQuoteProgressBarPosition
+{
+    [Description("置于底部")]
+    Bottom = 0,
+    [Description("置于顶部")]
+    Top = 1
+}
 
 public partial class LocalQuoteSettings : ObservableObject
 {
@@ -22,4 +31,10 @@ public partial class LocalQuoteSettings : ObservableObject
 
     [ObservableProperty]
     private DateTime _lastSwitchTime = DateTime.MinValue;
+
+    [ObservableProperty]
+    private bool _showProgressBar = true;
+
+    [ObservableProperty]
+    private LocalQuoteProgressBarPosition _progressBarPosition = LocalQuoteProgressBarPosition.Bottom;
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -63,6 +63,7 @@ public class Plugin : PluginBase
         services.AddSingleton(GlobalConstants.MainConfig);
         services.AddSingleton<FloatingWindowService>();
         services.AddSingleton<AdaptiveThemeSyncService>();
+        services.AddSingleton<UsbAutoPlayService>();
 
         // ========== 注册可选人脸识别 ==========
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -109,6 +110,7 @@ public class Plugin : PluginBase
                 IAppHost.GetService<FloatingWindowService>().Start();
             }
             IAppHost.GetService<AdaptiveThemeSyncService>().Start();
+            IAppHost.GetService<UsbAutoPlayService>().Start();
             _logger = IAppHost.GetService<ILogger<Plugin>>();
 
             _logger?.LogInformation("[SystemTools]实验性功能状态: {Status}", experimentalEnabled);
@@ -826,6 +828,7 @@ public class Plugin : PluginBase
     private void OnAppStopping(object? sender, EventArgs e)
     {
         IAppHost.GetService<AdaptiveThemeSyncService>().Stop();
+        IAppHost.GetService<UsbAutoPlayService>().Stop();
         AdvancedShutdownAction.CancelPlanOnAppStopping();
         if (GlobalConstants.MainConfig?.Data.EnableFloatingWindowFeature == true)
         {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -47,11 +47,11 @@ public class Plugin : PluginBase
     public override void Initialize(HostBuilderContext context, IServiceCollection services)
     {
         // ========== 初始化配置 ==========
-        Console.WriteLine("[SystemTools]-------------------------------------------------------------------\r\n" 
+        Console.WriteLine("[SystemTools]-------------------------------------------------------------------\r\n"
                           + GlobalConstants.Assets.AsciiLogo
-                          + "\r\n Copyright (C) 2026 Programmer_MrWang \r\n Licensed under GNU AGPLv3. \r\n" 
+                          + "\r\n Copyright (C) 2026 Programmer_MrWang \r\n Licensed under GNU AGPLv3. \r\n"
                           + "正在初始化SystemTools配置...-----------------------------------------------------------");
-        
+
         GlobalConstants.PluginConfigFolder = PluginConfigFolder;
         GlobalConstants.Information.PluginFolder = Info.PluginFolderPath;
         GlobalConstants.Information.PluginVersion = Info.Manifest.Version;
@@ -63,7 +63,7 @@ public class Plugin : PluginBase
         services.AddSingleton(GlobalConstants.MainConfig);
         services.AddSingleton<FloatingWindowService>();
         services.AddSingleton<AdaptiveThemeSyncService>();
-        
+
         // ========== 注册可选人脸识别 ==========
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -80,7 +80,7 @@ public class Plugin : PluginBase
                 }
             }
         }
-        
+
         // ========== 注册设置页面 ==========
         services.AddSettingsPage<SystemToolsSettingsPage>();
         services.AddSettingsPage<MoreFeaturesOptionsSettingsPage>();
@@ -160,7 +160,7 @@ public class Plugin : PluginBase
         // ========== 注册设置页面分组 ==========
         AppBase.Current.AppStarted += (_, _) => RegisterSettingsPageGroup(services);
     }
-    
+
     #region 依赖检查
 
     private void EnsureOptionalDependencyState()
@@ -257,6 +257,8 @@ public class Plugin : PluginBase
         RegisterActionIfEnabled<DisableDeviceAction, DisableDeviceSettingsControl>(services, config,
             "SystemTools.DisableDevice");
         RegisterActionIfEnabled<ShowToastAction, ShowToastSettingsControl>(services, config, "SystemTools.ShowToast");
+        RegisterActionIfEnabled<BackgroundPlayAudioAction, BackgroundPlayAudioSettingsControl>(services, config,
+            "SystemTools.BackgroundPlayAudio");
         RegisterActionIfEnabled<LoadTemporaryClassPlanAction, LoadTemporaryClassPlanSettingsControl>(services, config,
             "SystemTools.LoadTemporaryClassPlan");
 
@@ -341,7 +343,7 @@ public class Plugin : PluginBase
             "SystemTools.NextClassDisplay");
         RegisterComponentIfEnabled<BetterCarouselContainerComponent, BetterCarouselContainerSettingsControl>(services, config,
             "SystemTools.BetterCarouselContainer");
-        RegisterComponentIfEnabled<ScrollingTextComponent, ScrollingTextSettingsControl>(services, config, 
+        RegisterComponentIfEnabled<ScrollingTextComponent, ScrollingTextSettingsControl>(services, config,
             "SystemTools.ScrollingText");
 
     }
@@ -367,11 +369,13 @@ public class Plugin : PluginBase
     {
         _logger?.LogInformation("[SystemTools]正在注册 FFmpeg 依赖功能...");
 
-        services.AddAction<CameraCaptureAction, CameraCaptureSettingsControl>();
-
-        IActionService.ActionMenuTree["SystemTools 行动"]["实用工具…"].Add(
-            new ActionMenuTreeItem("SystemTools.CameraCapture", "摄像头抓拍", "\uE39E")
-        );
+        if (GlobalConstants.MainConfig!.Data.IsActionEnabled("SystemTools.CameraCapture"))
+        {
+            services.AddAction<CameraCaptureAction, CameraCaptureSettingsControl>();
+            IActionService.ActionMenuTree["SystemTools 行动"]["媒体工具…"].Add(
+                new ActionMenuTreeItem("SystemTools.CameraCapture", "摄像头抓拍", "\uE39E")
+            );
+        }
     }
 
     #endregion
@@ -474,6 +478,12 @@ public class Plugin : PluginBase
         {
             IActionService.ActionMenuTree["SystemTools 行动"].Add(new ActionMenuTreeGroup("实用工具…", "\uE352"));
             BuildUtilityMenu(config);
+        }
+
+        if (config.EnableFfmpegFeatures || HasAnyActionEnabled(config, "SystemTools.BackgroundPlayAudio"))
+        {
+            IActionService.ActionMenuTree["SystemTools 行动"].Add(new ActionMenuTreeGroup("媒体工具…", "\uE189"));
+            BuildMediaToolsMenu(config);
         }
 
         if (HasAnyActionEnabled(config, "SystemTools.ClearAllNotifications", "SystemTools.RestartAsAdmin", "SystemTools.LoadTemporaryClassPlan"))
@@ -724,6 +734,18 @@ public class Plugin : PluginBase
         if (items.Count > 0)
         {
             IActionService.ActionMenuTree["SystemTools 行动"]["实用工具…"].AddRange(items);
+        }
+    }
+
+    private void BuildMediaToolsMenu(MainConfigData config)
+    {
+        var items = new List<ActionMenuTreeItem>();
+        if (config.IsActionEnabled("SystemTools.BackgroundPlayAudio"))
+            items.Add(new ActionMenuTreeItem("SystemTools.BackgroundPlayAudio", "后台播放音频", "\uE189"));
+
+        if (items.Count > 0)
+        {
+            IActionService.ActionMenuTree["SystemTools 行动"]["媒体工具…"].AddRange(items);
         }
     }
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -248,7 +248,7 @@ public class Plugin : PluginBase
             "SystemTools.ChangeWallpaper");
         RegisterActionIfEnabled<SwitchThemeAction, ThemeSettingsControl>(services, config, "SystemTools.SwitchTheme");
 
-        // 实用工具（基础）
+        // 实用工具
         RegisterActionIfEnabled<ScreenShotAction, ScreenShotSettingsControl>(services, config,
             "SystemTools.ScreenShot");
         RegisterActionIfEnabled<SetVolumeAction, SetVolumeSettingsControl>(services, config, "SystemTools.SetVolume");
@@ -259,10 +259,12 @@ public class Plugin : PluginBase
         RegisterActionIfEnabled<DisableDeviceAction, DisableDeviceSettingsControl>(services, config,
             "SystemTools.DisableDevice");
         RegisterActionIfEnabled<ShowToastAction, ShowToastSettingsControl>(services, config, "SystemTools.ShowToast");
-        RegisterActionIfEnabled<BackgroundPlayAudioAction, BackgroundPlayAudioSettingsControl>(services, config,
-            "SystemTools.BackgroundPlayAudio");
         RegisterActionIfEnabled<LoadTemporaryClassPlanAction, LoadTemporaryClassPlanSettingsControl>(services, config,
             "SystemTools.LoadTemporaryClassPlan");
+        
+        // 媒体工具
+        RegisterActionIfEnabled<BackgroundPlayAudioAction, BackgroundPlayAudioSettingsControl>(services, config,
+            "SystemTools.BackgroundPlayAudio");
 
         // 悬浮窗设置
         if (config.EnableFloatingWindowFeature)
@@ -484,7 +486,7 @@ public class Plugin : PluginBase
 
         if (config.EnableFfmpegFeatures || HasAnyActionEnabled(config, "SystemTools.BackgroundPlayAudio"))
         {
-            IActionService.ActionMenuTree["SystemTools 行动"].Add(new ActionMenuTreeGroup("媒体工具…", "\uE189"));
+            IActionService.ActionMenuTree["SystemTools 行动"].Add(new ActionMenuTreeGroup("媒体工具…", "\uE342"));
             BuildMediaToolsMenu(config);
         }
 
@@ -743,7 +745,7 @@ public class Plugin : PluginBase
     {
         var items = new List<ActionMenuTreeItem>();
         if (config.IsActionEnabled("SystemTools.BackgroundPlayAudio"))
-            items.Add(new ActionMenuTreeItem("SystemTools.BackgroundPlayAudio", "后台播放音频", "\uE189"));
+            items.Add(new ActionMenuTreeItem("SystemTools.BackgroundPlayAudio", "后台播放音频", "\uEBCC"));
 
         if (items.Count > 0)
         {

--- a/Services/AdaptiveThemeSyncService.cs
+++ b/Services/AdaptiveThemeSyncService.cs
@@ -3,9 +3,10 @@ using ClassIsland.Core;
 using ClassIsland.Core.Abstractions.Services;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Windows.Forms;
 using ClassIsland.Shared;
 using SystemTools.Shared;
@@ -73,15 +74,8 @@ public class AdaptiveThemeSyncService(ILogger<AdaptiveThemeSyncService> logger)
 
     private static int? DetectThemeByScreenBackground()
     {
-        var handle = Process.GetCurrentProcess().MainWindowHandle;
-        if (handle == IntPtr.Zero || !GetWindowRect(handle, out var rect))
-        {
-            return null;
-        }
-
-        var mainWindow = Rectangle.FromLTRB(rect.Left, rect.Top, rect.Right, rect.Bottom);
-        var screen = Screen.FromRectangle(mainWindow);
-        var captureRect = BuildTargetArea(screen.Bounds, mainWindow);
+        var screen = ResolveTargetScreen();
+        var captureRect = BuildTargetArea(screen.Bounds, ResolveUseTopAreaFromClassIslandSettings());
 
         using var bitmap = new Bitmap(captureRect.Width, captureRect.Height);
         using var graphics = Graphics.FromImage(bitmap);
@@ -114,25 +108,87 @@ public class AdaptiveThemeSyncService(ILogger<AdaptiveThemeSyncService> logger)
         return luminance < 128 ? 1 : 0;
     }
 
-    private static Rectangle BuildTargetArea(Rectangle screenBounds, Rectangle mainWindow)
+    private static Rectangle BuildTargetArea(Rectangle screenBounds, bool useTopArea)
     {
         var topHeight = Math.Max(1, screenBounds.Height / 5);
         var bottomY = screenBounds.Bottom - topHeight;
 
-        var isTop = mainWindow.Top + mainWindow.Height / 2 <= screenBounds.Top + screenBounds.Height / 2;
-        return isTop
+        return useTopArea
             ? new Rectangle(screenBounds.Left, screenBounds.Top, screenBounds.Width, topHeight)
             : new Rectangle(screenBounds.Left, bottomY, screenBounds.Width, topHeight);
     }
 
-    [DllImport("user32.dll")]
-    private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
-
-    private struct RECT
+    private static Screen ResolveTargetScreen()
     {
-        public int Left;
-        public int Top;
-        public int Right;
-        public int Bottom;
+        var monitorIndex = ReadClassIslandWindowDockingMonitorIndex();
+        if (monitorIndex >= 0 && monitorIndex < Screen.AllScreens.Length)
+        {
+            return Screen.AllScreens[monitorIndex];
+        }
+
+        return Screen.PrimaryScreen ?? Screen.AllScreens[0];
+    }
+
+    private static bool ResolveUseTopAreaFromClassIslandSettings()
+    {
+        var dockingLocation = ReadClassIslandWindowDockingLocation();
+        if (dockingLocation is null)
+        {
+            return true;
+        }
+
+        // 0=左上角,1=中上侧,2=右上角,3=左下角,4=中下侧,5=右下角
+        return dockingLocation is 0 or 1 or 2;
+    }
+
+    private static int? ReadClassIslandWindowDockingLocation() =>
+        ReadIntFromClassIslandSettings(["windowDockingLocation", "WindowDockingLocation"]);
+
+    private static int? ReadClassIslandWindowDockingMonitorIndex() =>
+        ReadIntFromClassIslandSettings(["windowDockingMonitorIndex", "WindowDockingMonitorIndex"]);
+
+    private static int? ReadIntFromClassIslandSettings(string[] keys)
+    {
+        foreach (var settingsPath in GetPossibleClassIslandSettingsPaths())
+        {
+            if (!File.Exists(settingsPath))
+            {
+                continue;
+            }
+
+            try
+            {
+                using var stream = File.OpenRead(settingsPath);
+                using var document = JsonDocument.Parse(stream);
+                var root = document.RootElement;
+                foreach (var key in keys)
+                {
+                    if (root.TryGetProperty(key, out var value) && value.TryGetInt32(out var intValue))
+                    {
+                        return intValue;
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore parse errors and try next candidate.
+            }
+        }
+
+        return null;
+    }
+
+    private static string[] GetPossibleClassIslandSettingsPaths()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var processDirectory = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        return
+        [
+            Path.Combine(localAppData, "ClassIsland", "Settings.json"),
+            Path.Combine(localAppData, "ClassIsland", "Config", "Settings.json"),
+            Path.Combine(processDirectory, "Settings.json"),
+            Path.Combine(processDirectory, "Config", "Settings.json")
+        ];
     }
 }

--- a/Services/AdaptiveThemeSyncService.cs
+++ b/Services/AdaptiveThemeSyncService.cs
@@ -121,9 +121,9 @@ public class AdaptiveThemeSyncService(ILogger<AdaptiveThemeSyncService> logger)
     private static Screen ResolveTargetScreen()
     {
         var monitorIndex = ReadClassIslandWindowDockingMonitorIndex();
-        if (monitorIndex >= 0 && monitorIndex < Screen.AllScreens.Length)
+        if (monitorIndex is int idx && idx >= 0 && idx < Screen.AllScreens.Length)
         {
-            return Screen.AllScreens[monitorIndex];
+            return Screen.AllScreens[idx];
         }
 
         return Screen.PrimaryScreen ?? Screen.AllScreens[0];

--- a/Services/UsbAutoPlayService.cs
+++ b/Services/UsbAutoPlayService.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Management;
+using System.Runtime.InteropServices;
+using SystemTools.Shared;
+
+namespace SystemTools.Services;
+
+public class UsbAutoPlayService(ILogger<UsbAutoPlayService> logger)
+{
+    private readonly ILogger<UsbAutoPlayService> _logger = logger;
+    private ManagementEventWatcher? _volumeInsertWatcher;
+
+    public void Start()
+    {
+        ApplyConfig();
+    }
+
+    public void Stop()
+    {
+        StopWatcher();
+    }
+
+    public void ApplyConfig()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            StopWatcher();
+            return;
+        }
+
+        if (GlobalConstants.MainConfig?.Data.AutoOpenUsbDriveOnInsert != true)
+        {
+            StopWatcher();
+            return;
+        }
+
+        if (_volumeInsertWatcher != null)
+        {
+            return;
+        }
+
+        try
+        {
+            const string query = "SELECT * FROM Win32_VolumeChangeEvent WHERE EventType = 2";
+            _volumeInsertWatcher = new ManagementEventWatcher(new WqlEventQuery(query));
+            _volumeInsertWatcher.EventArrived += OnVolumeInserted;
+            _volumeInsertWatcher.Start();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "自动播放服务启动失败。");
+            StopWatcher();
+        }
+    }
+
+    private void OnVolumeInserted(object sender, EventArrivedEventArgs e)
+    {
+        var driveName = e.NewEvent.Properties["DriveName"]?.Value?.ToString();
+        if (string.IsNullOrWhiteSpace(driveName))
+        {
+            return;
+        }
+
+        var driveRoot = Path.GetPathRoot(driveName) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(driveRoot))
+        {
+            return;
+        }
+
+        try
+        {
+            var driveInfo = new DriveInfo(driveRoot);
+            if (!driveInfo.IsReady || driveInfo.DriveType != DriveType.Removable)
+            {
+                return;
+            }
+
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = driveRoot,
+                UseShellExecute = true
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "自动打开U盘失败：{DriveRoot}", driveRoot);
+        }
+    }
+
+    private void StopWatcher()
+    {
+        if (_volumeInsertWatcher == null)
+        {
+            return;
+        }
+
+        _volumeInsertWatcher.EventArrived -= OnVolumeInserted;
+        try
+        {
+            _volumeInsertWatcher.Stop();
+        }
+        catch
+        {
+            // Ignore stop errors.
+        }
+
+        _volumeInsertWatcher.Dispose();
+        _volumeInsertWatcher = null;
+    }
+}

--- a/Settings/BackgroundPlayAudioSettings.cs
+++ b/Settings/BackgroundPlayAudioSettings.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace SystemTools.Settings;
+
+public class BackgroundPlayAudioSettings
+{
+    [JsonPropertyName("audioFilePath")]
+    public string AudioFilePath { get; set; } = string.Empty;
+
+    [JsonPropertyName("waitForPlaybackCompleted")]
+    public bool WaitForPlaybackCompleted { get; set; }
+}

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
@@ -8,7 +8,7 @@
 
             <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE520;}"
                                        Header="自动匹配主界面背景色到 ClassIsland 主题"
-                                       Description="每 2 秒检测屏幕顶部/底部五分之一亮度：偏黑切换黑暗，偏白切换明亮。">
+                                       Description="实时监测主界面所在区域色彩，偏黑则切换黑暗，偏白则切换明亮">
                 <controls:SettingsExpander.Footer>
                     <ToggleSwitch IsChecked="{Binding Config.AutoMatchMainBackgroundTheme, Mode=TwoWay}"
                                   Checked="AutoMatchThemeToggle_OnChanged"
@@ -16,9 +16,9 @@
                 </controls:SettingsExpander.Footer>
             </controls:SettingsExpander>
 
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE8B7;}"
+            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xEE81;}"
                                        Header="自动播放"
-                                       Description="开启后，当插入U盘时自动打开该U盘。">
+                                       Description="当插入U盘设备时时自动打开">
                 <controls:SettingsExpander.Footer>
                     <ToggleSwitch IsChecked="{Binding Config.AutoOpenUsbDriveOnInsert, Mode=TwoWay}"
                                   Checked="AutoOpenUsbToggle_OnChanged"

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
@@ -16,6 +16,16 @@
                 </controls:SettingsExpander.Footer>
             </controls:SettingsExpander>
 
+            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE8B7;}"
+                                       Header="自动播放"
+                                       Description="开启后，当插入U盘时自动打开该U盘。">
+                <controls:SettingsExpander.Footer>
+                    <ToggleSwitch IsChecked="{Binding Config.AutoOpenUsbDriveOnInsert, Mode=TwoWay}"
+                                  Checked="AutoOpenUsbToggle_OnChanged"
+                                  Unchecked="AutoOpenUsbToggle_OnChanged" />
+                </controls:SettingsExpander.Footer>
+            </controls:SettingsExpander>
+
         </StackPanel>
     </ScrollViewer>
 </ci:SettingsPageBase>

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
@@ -29,4 +29,10 @@ public partial class MoreFeaturesOptionsSettingsPage : SettingsPageBase
         GlobalConstants.MainConfig?.Save();
     }
 
+    private void AutoOpenUsbToggle_OnChanged(object? sender, RoutedEventArgs e)
+    {
+        var service = ClassIsland.Shared.IAppHost.GetService<UsbAutoPlayService>();
+        service.ApplyConfig();
+        GlobalConstants.MainConfig?.Save();
+    }
 }

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
@@ -31,6 +31,11 @@ public partial class MoreFeaturesOptionsSettingsPage : SettingsPageBase
 
     private void AutoOpenUsbToggle_OnChanged(object? sender, RoutedEventArgs e)
     {
+        if (sender is Avalonia.Controls.ToggleSwitch toggleSwitch)
+        {
+            Config.AutoOpenUsbDriveOnInsert = toggleSwitch.IsChecked == true;
+        }
+
         var service = ClassIsland.Shared.IAppHost.GetService<UsbAutoPlayService>();
         service.ApplyConfig();
         GlobalConstants.MainConfig?.Save();

--- a/SettingsPage/SystemToolsSettingsViewModel.cs
+++ b/SettingsPage/SystemToolsSettingsViewModel.cs
@@ -201,6 +201,8 @@ public partial class SystemToolsSettingsViewModel : ObservableObject, IDisposabl
             ("SystemTools.ShowToast", "拉起自定义Windows通知", "实用工具"),
             ("SystemTools.DisableDevice", "禁用硬件设备", "实用工具"),
             ("SystemTools.EnableDevice", "启用硬件设备", "实用工具"),
+            ("SystemTools.BackgroundPlayAudio", "后台播放音频", "媒体工具"),
+            ("SystemTools.CameraCapture", "摄像头抓拍", "媒体工具"),
             ("SystemTools.TriggerCustomTrigger", "触发指定触发器", null),
             ("SystemTools.RestartAsAdmin", "重启应用为管理员身份", "ClassIsland"),
             ("SystemTools.ClearAllNotifications", "清除全部提醒", "ClassIsland"),

--- a/SettingsPage/SystemToolsSettingsViewModel.cs
+++ b/SettingsPage/SystemToolsSettingsViewModel.cs
@@ -57,7 +57,6 @@ public partial class SystemToolsSettingsViewModel : ObservableObject, IDisposabl
 {
     [ObservableProperty] private MainConfigData _settings;
 
-    // 两个独立的下载按钮启用状态
     [ObservableProperty] private bool _isFfmpegDownloadEnabled = true;
     [ObservableProperty] private bool _isFaceModelsDownloadEnabled = true;
 
@@ -67,7 +66,7 @@ public partial class SystemToolsSettingsViewModel : ObservableObject, IDisposabl
 
     [ObservableProperty] private ObservableCollection<UnifiedFeatureItem> _featureItems = new();
 
-    // Drawer 相关属性
+    // Drawer 
     [ObservableProperty] private bool _isFeatureDrawerOpen = false;
     [ObservableProperty] private object? _featureDrawerContent;
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ name: SystemTools
 description: 提供多彩而丰富的更多 组件/行动/触发器/实用工具
 entranceAssembly: "SystemTools.dll"
 url: https://github.com/Programmer-MrWang/SystemTools
-version: 2.5.0.103
+version: 2.5.0.104
 apiVersion: 2.0.0.0
 author: Programmer-MrWang
 readme: README.md


### PR DESCRIPTION
### Motivation
- Add a simple background audio playback action and expose it in the UI and action menus to provide a lightweight media tool for users. 
- Improve the carousel component with a new `Fade` animation style to offer smoother transitions. 
- Add an optional progress bar to the `LocalQuoteComponent` so users can see the remaining display time for each quote. 
- Make adaptive theme detection more robust by reading ClassIsland window docking settings and fallback locations rather than relying on the current process main window rectangle.

### Description
- Introduced a new action `BackgroundPlayAudioAction` with settings class `BackgroundPlayAudioSettings` and settings control `BackgroundPlayAudioSettingsControl`, and registered the action and settings page in `Plugin.cs` and menus under a new "媒体工具…" group. 
- Added `Fade` animation support to `BetterCarouselContainerComponent` by introducing `_fadeInAnimation`/`_fadeOutAnimation` and updated selection logic to support `BetterCarouselAnimationStyle.Fade` (enum value and description added). 
- Enhanced `LocalQuoteComponent` to show optional top/bottom progress bars including UI changes in `LocalQuoteComponent.axaml`, a new `LocalQuoteProgressBarPosition` enum and settings fields, timers and progress calculation logic, and corresponding settings control updates (`LocalQuoteSettings`, `LocalQuoteSettingsControl.axaml` and code-behind). 
- Improved adaptive theme detection in `AdaptiveThemeSyncService` by computing the capture area from the target screen and by reading ClassIsland settings files for docking location/monitor index; removed dependence on `GetWindowRect` and added JSON settings parsing fallback paths. 
- Adjusted conditional registration for FFmpeg camera capture so it only registers when the feature and action are enabled; minor whitespace and logging string formatting cleanups in `Plugin.cs`.

### Testing
- Ran a project build using `dotnet build` which completed successfully. 
- No new automated unit tests were added for these UI and integration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb959058a8832b83886fd50c3e7360)