### PR TITLE
feat: add tray floating-window toggle and local quote playback order

### DIFF
--- a/Controls/Components/LocalQuoteComponent.axaml.cs
+++ b/Controls/Components/LocalQuoteComponent.axaml.cs
@@ -35,6 +35,7 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
     private readonly List<string> _quotes = [];
     private readonly Animation _swapOutAnimation;
     private readonly Animation _swapInAnimation;
+    private readonly Random _random = new();
     private int _currentIndex = -1;
     private string _loadedPath = string.Empty;
     private bool _isAnimating;
@@ -172,6 +173,12 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         if (e.PropertyName == nameof(Settings.QuotesFilePath))
         {
             LoadQuotesFromFile(Settings.QuotesFilePath, showFirstQuote: true);
+            EnsureTimersForQuoteState();
+        }
+
+        if (e.PropertyName == nameof(Settings.PlaybackOrder))
+        {
+            ShowNextQuote();
             EnsureTimersForQuoteState();
         }
     }
@@ -323,7 +330,9 @@ public partial class LocalQuoteComponent : ComponentBase<LocalQuoteSettings>, IN
         // 因此需要在当前轮换开始时立即重置，而不是等动画播放完成后再重置。
         RestartProgressCycle(_carouselTimer.Interval.TotalSeconds);
 
-        _currentIndex = (_currentIndex + 1) % _quotes.Count;
+        _currentIndex = Settings.PlaybackOrder == LocalQuotePlaybackOrder.Random
+            ? _random.Next(_quotes.Count)
+            : (_currentIndex + 1) % _quotes.Count;
         var next = _quotes[_currentIndex];
 
         // 更新持久化数据

--- a/Controls/Components/LocalQuoteSettingsControl.axaml
+++ b/Controls/Components/LocalQuoteSettingsControl.axaml
@@ -55,6 +55,22 @@
                                        Value="{Binding Settings.CarouselIntervalSeconds, Mode=TwoWay}" />
                     </controls:SettingsExpander.Footer>
                 </controls:SettingsExpander>
+
+                <controls:SettingsExpander
+                    Header="轮播顺序"
+                    Description="设置一言文本的轮播方式"
+                    IconSource="{ci:FluentIconSource &#xE143;}">
+                    <controls:SettingsExpander.Footer>
+                        <ComboBox SelectedItem="{Binding Settings.PlaybackOrder, Mode=TwoWay}"
+                                  ItemsSource="{Binding PlaybackOrders}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </controls:SettingsExpander.Footer>
+                </controls:SettingsExpander>
                 
                 <controls:SettingsExpander
                     Header="记忆轮播行"

--- a/Controls/Components/LocalQuoteSettingsControl.axaml.cs
+++ b/Controls/Components/LocalQuoteSettingsControl.axaml.cs
@@ -9,6 +9,7 @@ namespace SystemTools.Controls.Components;
 public partial class LocalQuoteSettingsControl : ComponentBase<LocalQuoteSettings>
 {
     public Array ProgressBarPositions { get; } = Enum.GetValues(typeof(LocalQuoteProgressBarPosition));
+    public Array PlaybackOrders { get; } = Enum.GetValues(typeof(LocalQuotePlaybackOrder));
 
     public LocalQuoteSettingsControl()
     {

--- a/Models/ComponentSettings/LocalQuoteSettings.cs
+++ b/Models/ComponentSettings/LocalQuoteSettings.cs
@@ -12,6 +12,14 @@ public enum LocalQuoteProgressBarPosition
     Top = 1
 }
 
+public enum LocalQuotePlaybackOrder
+{
+    [Description("逐行播放")]
+    Sequential = 0,
+    [Description("随机播放")]
+    Random = 1
+}
+
 public partial class LocalQuoteSettings : ObservableObject
 {
     [ObservableProperty]
@@ -37,4 +45,7 @@ public partial class LocalQuoteSettings : ObservableObject
 
     [ObservableProperty]
     private LocalQuoteProgressBarPosition _progressBarPosition = LocalQuoteProgressBarPosition.Bottom;
+
+    [ObservableProperty]
+    private LocalQuotePlaybackOrder _playbackOrder = LocalQuotePlaybackOrder.Sequential;
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.ComponentModel;
 using SystemTools.Actions;
 using SystemTools.ConfigHandlers;
 using SystemTools.Controls;
@@ -144,6 +145,7 @@ public class Plugin : PluginBase
                 _logger?.LogWarning("[SystemTools]人脸识别功能已自动关闭：缺少 runtimes、Models 或 OpenCvSharp/Dlib 依赖，并已清理对应验证器配置。");
             }
             _logger?.LogInformation("[SystemTools]SystemTools 启动完成");
+            RegisterOrUpdateFloatingWindowTrayMenu();
         };
 
         // ========== 注册实验性功能 ==========
@@ -900,6 +902,91 @@ public class Plugin : PluginBase
             IAppHost.GetService<FloatingWindowService>().Stop();
         }
         _logger?.LogInformation("[SystemTools]关闭插件SystemTools，保存配置...");
+        UnregisterFloatingWindowTrayMenu();
         GlobalConstants.MainConfig?.Save();
+    }
+
+    private void RegisterOrUpdateFloatingWindowTrayMenu()
+    {
+        var config = GlobalConstants.MainConfig?.Data;
+        if (config == null)
+        {
+            return;
+        }
+
+        if (_toggleFloatingWindowMenuItem == null)
+        {
+            _toggleFloatingWindowMenuItem = new NativeMenuItem();
+            _toggleFloatingWindowMenuItem.Click += (_, _) =>
+            {
+                var data = GlobalConstants.MainConfig?.Data;
+                if (data == null || !data.EnableFloatingWindowFeature)
+                {
+                    return;
+                }
+
+                data.ShowFloatingWindow = !data.ShowFloatingWindow;
+                IAppHost.GetService<FloatingWindowService>().UpdateWindowState();
+                UpdateFloatingWindowTrayMenuHeader();
+                GlobalConstants.MainConfig?.Save();
+            };
+
+            config.PropertyChanged += OnMainConfigDataPropertyChanged;
+        }
+
+        if (!config.EnableFloatingWindowFeature)
+        {
+            UnregisterFloatingWindowTrayMenu();
+            return;
+        }
+
+        var trayService = IAppHost.TryGetService<ITaskBarIconService>();
+        if (trayService == null)
+        {
+            return;
+        }
+
+        if (!trayService.MoreOptionsMenuItems.Contains(_toggleFloatingWindowMenuItem))
+        {
+            trayService.MoreOptionsMenuItems.Add(_toggleFloatingWindowMenuItem);
+        }
+
+        UpdateFloatingWindowTrayMenuHeader();
+    }
+
+    private void UnregisterFloatingWindowTrayMenu()
+    {
+        var trayService = IAppHost.TryGetService<ITaskBarIconService>();
+        if (trayService == null || _toggleFloatingWindowMenuItem == null)
+        {
+            return;
+        }
+
+        if (trayService.MoreOptionsMenuItems.Contains(_toggleFloatingWindowMenuItem))
+        {
+            trayService.MoreOptionsMenuItems.Remove(_toggleFloatingWindowMenuItem);
+        }
+    }
+
+    private void OnMainConfigDataPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is not (nameof(MainConfigData.ShowFloatingWindow) or nameof(MainConfigData.EnableFloatingWindowFeature)))
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(RegisterOrUpdateFloatingWindowTrayMenu);
+    }
+
+    private void UpdateFloatingWindowTrayMenuHeader()
+    {
+        if (_toggleFloatingWindowMenuItem == null)
+        {
+            return;
+        }
+
+        _toggleFloatingWindowMenuItem.Header = GlobalConstants.MainConfig?.Data.ShowFloatingWindow == true
+            ? "隐藏悬浮窗"
+            : "显示悬浮窗";
     }
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ name: SystemTools
 description: 提供多彩而丰富的更多 组件/行动/触发器/实用工具
 entranceAssembly: "SystemTools.dll"
 url: https://github.com/Programmer-MrWang/SystemTools
-version: 2.5.0.105
+version: 2.5.0.106
 apiVersion: 2.0.0.0
 author: Programmer-MrWang
 readme: README.md


### PR DESCRIPTION
### Motivation

- Provide a tray-menu toggle for the floating window so users can `显示/隐藏悬浮窗` from the system tray and keep that control synchronized with the main settings page.  
- Follow the pattern used by `DutyIsland` (manipulating `ITaskBarIconService.MoreOptionsMenuItems`) to register/unregister tray items only when the floating-window feature is enabled.  
- Extend the "本地一言" component with a user-selectable playback order so text lines can be played sequentially (existing behavior) or randomly.

### Description

- Add tray integration in `Plugin.cs`: implement `RegisterOrUpdateFloatingWindowTrayMenu`, `UnregisterFloatingWindowTrayMenu`, `OnMainConfigDataPropertyChanged`, and `UpdateFloatingWindowTrayMenuHeader`, and call registration on startup and unregistration on stop; the tray item toggles `MainConfigData.ShowFloatingWindow`, calls `FloatingWindowService.UpdateWindowState()`, and persists the config.  
- Add `LocalQuotePlaybackOrder` enum and `PlaybackOrder` observable property in `Models/ComponentSettings/LocalQuoteSettings.cs` with default `Sequential`.  
- Update settings UI and control: add a `轮播顺序` settings expander (icon `E143`) and a ComboBox bound to the new enum in `Controls/Components/LocalQuoteSettingsControl.axaml` and expose `PlaybackOrders` in the control code-behind.  
- Update `LocalQuoteComponent` runtime logic to support random playback by adding a `Random` instance, responding to `PlaybackOrder` changes, and choosing a random index when `PlaybackOrder == LocalQuotePlaybackOrder.Random` while preserving existing sequential behavior and persistence semantics.

### Testing

- Attempted an automated build with `dotnet build -v minimal`, but the execution environment does not have `dotnet` installed so the build could not be performed (failed).  
- No other automated test suites were executed in this environment; changes were staged and committed locally (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe06913430832bae2a515f2d2709ff)