### PR TITLE
新增“切换系统强调色”行动，修复媒体规则抖动并统一主题切换逻辑

### DIFF
--- a/Actions/SwitchSystemAccentColorAction.cs
+++ b/Actions/SwitchSystemAccentColorAction.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using SystemTools.Settings;
 
@@ -14,6 +15,13 @@ public class SwitchSystemAccentColorAction(ILogger<SwitchSystemAccentColorAction
 {
     private readonly ILogger<SwitchSystemAccentColorAction> _logger = logger;
 
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+
+    const uint HWND_BROADCAST = 0xFFFF;
+    const uint WM_SETTINGCHANGE = 0x001A;
+    const uint SMTO_ABORTIFHUNG = 0x0002;
+
     protected override async Task OnInvoke()
     {
         if (Settings == null || string.IsNullOrWhiteSpace(Settings.ColorHex)) return;
@@ -21,14 +29,22 @@ public class SwitchSystemAccentColorAction(ILogger<SwitchSystemAccentColorAction
         try
         {
             var color = ParseColor(Settings.ColorHex);
-            var dword = ((uint)color.A << 24) | ((uint)color.R << 16) | ((uint)color.G << 8) | color.B;
+            // Windows 使用 ABGR 格式（低位字节是 R）
+            var dword = ((uint)color.A << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | color.R;
+            // ColorizationColor 通常使用 C4 (196) 作为 Alpha
+            var colorizationDword = (0xC4u << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | color.R;
 
             using var dwmKey = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\DWM");
             dwmKey?.SetValue("AccentColor", dword, RegistryValueKind.DWord);
+            dwmKey?.SetValue("ColorizationColor", colorizationDword, RegistryValueKind.DWord);
+            dwmKey?.SetValue("ColorizationAfterglow", colorizationDword, RegistryValueKind.DWord);
             dwmKey?.SetValue("ColorPrevalence", 1, RegistryValueKind.DWord);
 
             using var explorerKey = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\Accent");
             explorerKey?.SetValue("AccentColorMenu", dword, RegistryValueKind.DWord);
+
+            // 通知 Windows 刷新主题色
+            SendMessageTimeout((IntPtr)HWND_BROADCAST, WM_SETTINGCHANGE, (UIntPtr)0, "ImmersiveColorSet", SMTO_ABORTIFHUNG, 5000, out _);
 
             _logger.LogInformation("系统强调色已切换为 {Color}", Settings.ColorHex);
         }

--- a/Actions/SwitchSystemAccentColorAction.cs
+++ b/Actions/SwitchSystemAccentColorAction.cs
@@ -1,0 +1,53 @@
+using ClassIsland.Core.Abstractions.Automation;
+using ClassIsland.Core.Attributes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using SystemTools.Settings;
+
+namespace SystemTools.Actions;
+
+[ActionInfo("SystemTools.SwitchSystemAccentColor", "切换系统强调色", "\uE790", false)]
+public class SwitchSystemAccentColorAction(ILogger<SwitchSystemAccentColorAction> logger) : ActionBase<AccentColorSettings>
+{
+    private readonly ILogger<SwitchSystemAccentColorAction> _logger = logger;
+
+    protected override async Task OnInvoke()
+    {
+        if (Settings == null || string.IsNullOrWhiteSpace(Settings.ColorHex)) return;
+
+        try
+        {
+            var color = ParseColor(Settings.ColorHex);
+            var dword = ((uint)color.A << 24) | ((uint)color.R << 16) | ((uint)color.G << 8) | color.B;
+
+            using var dwmKey = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\DWM");
+            dwmKey?.SetValue("AccentColor", dword, RegistryValueKind.DWord);
+            dwmKey?.SetValue("ColorPrevalence", 1, RegistryValueKind.DWord);
+
+            using var explorerKey = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\Accent");
+            explorerKey?.SetValue("AccentColorMenu", dword, RegistryValueKind.DWord);
+
+            _logger.LogInformation("系统强调色已切换为 {Color}", Settings.ColorHex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "切换系统强调色失败");
+            throw;
+        }
+
+        await base.OnInvoke();
+    }
+
+    private static (byte A, byte R, byte G, byte B) ParseColor(string colorHex)
+    {
+        var hex = colorHex.Trim().TrimStart('#');
+        if (hex.Length == 6) hex = "FF" + hex;
+        if (hex.Length != 8) throw new FormatException("颜色格式无效");
+
+        var value = uint.Parse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        return ((byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value);
+    }
+}

--- a/Controls/AccentColorSettingsControl.cs
+++ b/Controls/AccentColorSettingsControl.cs
@@ -1,0 +1,34 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using ClassIsland.Core.Abstractions.Controls;
+using SystemTools.Settings;
+
+namespace SystemTools.Controls;
+
+public class AccentColorSettingsControl : ActionSettingsControlBase<AccentColorSettings>
+{
+    private readonly ColorPicker _colorPicker;
+
+    public AccentColorSettingsControl()
+    {
+        var panel = new StackPanel { Spacing = 10, Margin = new(10) };
+        panel.Children.Add(new TextBlock { Text = "切换系统强调色", FontSize = 14, FontWeight = Avalonia.Media.FontWeight.Bold });
+
+        _colorPicker = new ColorPicker
+        {
+            IsAlphaEnabled = false,
+            HorizontalAlignment = HorizontalAlignment.Left
+        };
+        _colorPicker.ColorChanged += (_, _) => Settings.ColorHex = _colorPicker.Color.ToString();
+
+        panel.Children.Add(_colorPicker);
+        Content = panel;
+    }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        if (Avalonia.Media.Color.TryParse(Settings.ColorHex, out var color))
+            _colorPicker.Color = color;
+    }
+}

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -492,7 +492,7 @@ public class Plugin : PluginBase
         }
 
         // 系统个性化
-        if (HasAnyActionEnabled(config, "SystemTools.ChangeWallpaper", "SystemTools.SwitchTheme"))
+        if (HasAnyActionEnabled(config, "SystemTools.ChangeWallpaper", "SystemTools.SwitchTheme", "SystemTools.SwitchSystemAccentColor"))
         {
             IActionService.ActionMenuTree["SystemTools 行动"].Add(new ActionMenuTreeGroup("系统个性化…", "\uF42F"));
             BuildPersonalizationMenu(config);

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -258,6 +258,7 @@ public class Plugin : PluginBase
         RegisterActionIfEnabled<ChangeWallpaperAction, ChangeWallpaperSettingsControl>(services, config,
             "SystemTools.ChangeWallpaper");
         RegisterActionIfEnabled<SwitchThemeAction, ThemeSettingsControl>(services, config, "SystemTools.SwitchTheme");
+        RegisterActionIfEnabled<SwitchSystemAccentColorAction, AccentColorSettingsControl>(services, config, "SystemTools.SwitchSystemAccentColor");
 
         // 实用工具
         RegisterActionIfEnabled<ScreenShotAction, ScreenShotSettingsControl>(services, config,
@@ -625,6 +626,9 @@ public class Plugin : PluginBase
         return current >= start || current <= end;
     }
 
+    private static DateTime _lastMediaRuleCheckAt = DateTime.MinValue;
+    private static bool _lastMediaRuleResult;
+
     private static bool HandleMediaMusicPlayingRule(object? settings)
     {
         if (!OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17134))
@@ -632,28 +636,32 @@ public class Plugin : PluginBase
             return false;
         }
 
+        var now = DateTime.UtcNow;
+        if (now - _lastMediaRuleCheckAt < TimeSpan.FromMilliseconds(800))
+        {
+            return _lastMediaRuleResult;
+        }
+
         try
         {
             var manager = WinMedia.GlobalSystemMediaTransportControlsSessionManager.RequestAsync()
                 .AsTask().GetAwaiter().GetResult();
 
-            if (manager == null)
-                return false;
-
-            var sessions = manager.GetSessions();
-            if (sessions == null || sessions.Count == 0)
-                return false;
-
-            return sessions.Any(session =>
+            var sessions = manager?.GetSessions();
+            var isPlaying = sessions != null && sessions.Any(session =>
             {
                 var playbackInfo = session.GetPlaybackInfo();
-                return playbackInfo != null &&
-                       playbackInfo.PlaybackStatus == WinMedia.GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing;
+                return playbackInfo?.PlaybackStatus == WinMedia.GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing;
             });
+
+            _lastMediaRuleResult = isPlaying;
+            _lastMediaRuleCheckAt = now;
+            return isPlaying;
         }
         catch
         {
-            return false;
+            _lastMediaRuleCheckAt = now;
+            return _lastMediaRuleResult;
         }
     }
 
@@ -768,6 +776,8 @@ public class Plugin : PluginBase
             items.Add(new ActionMenuTreeItem("SystemTools.ChangeWallpaper", "切换壁纸", "\uE9BC"));
         if (config.IsActionEnabled("SystemTools.SwitchTheme"))
             items.Add(new ActionMenuTreeItem("SystemTools.SwitchTheme", "切换主题色", "\uF42F"));
+        if (config.IsActionEnabled("SystemTools.SwitchSystemAccentColor"))
+            items.Add(new ActionMenuTreeItem("SystemTools.SwitchSystemAccentColor", "切换系统强调色", "\uE790"));
 
         if (items.Count > 0)
         {

--- a/Services/AdaptiveThemeSyncService.cs
+++ b/Services/AdaptiveThemeSyncService.cs
@@ -1,6 +1,7 @@
 using Avalonia.Threading;
 using ClassIsland.Core;
 using ClassIsland.Core.Abstractions.Services;
+using System.Reflection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Drawing;
@@ -56,13 +57,7 @@ public class AdaptiveThemeSyncService(ILogger<AdaptiveThemeSyncService> logger)
                 return;
             }
 
-            var themeService = IAppHost.TryGetService<IThemeService>();
-            if (themeService == null)
-            {
-                return;
-            }
-
-            themeService.SetTheme(targetTheme.Value, null);
+            ApplyThemeLikeAppSettings(targetTheme.Value);
             _lastAppliedTheme = targetTheme;
             _logger.LogDebug("已自动匹配主题为：{Theme}", targetTheme == 1 ? "黑暗" : "明亮");
         }
@@ -176,6 +171,28 @@ public class AdaptiveThemeSyncService(ILogger<AdaptiveThemeSyncService> logger)
         }
 
         return null;
+    }
+
+    private static void ApplyThemeLikeAppSettings(int targetTheme)
+    {
+        var settingsServiceObj = IAppHost.TryGetService<object>();
+        if (settingsServiceObj != null)
+        {
+            var type = settingsServiceObj.GetType();
+            if (type.Name == "SettingsService")
+            {
+                var settingsProp = type.GetProperty("Settings", BindingFlags.Instance | BindingFlags.Public);
+                var settings = settingsProp?.GetValue(settingsServiceObj);
+                var themeProp = settings?.GetType().GetProperty("Theme", BindingFlags.Instance | BindingFlags.Public);
+                if (themeProp?.CanWrite == true)
+                {
+                    themeProp.SetValue(settings, targetTheme);
+                    return;
+                }
+            }
+        }
+
+        IAppHost.TryGetService<IThemeService>()?.SetTheme(targetTheme, null);
     }
 
     private static string[] GetPossibleClassIslandSettingsPaths()

--- a/Settings/AccentColorSettings.cs
+++ b/Settings/AccentColorSettings.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace SystemTools.Settings;
+
+public class AccentColorSettings
+{
+    [JsonPropertyName("colorHex")] public string ColorHex { get; set; } = "#FF0078D4";
+}

--- a/SettingsPage/SystemToolsSettingsViewModel.cs
+++ b/SettingsPage/SystemToolsSettingsViewModel.cs
@@ -195,6 +195,7 @@ public partial class SystemToolsSettingsViewModel : ObservableObject, IDisposabl
             ("SystemTools.Delete", "删除", "文件操作"),
             ("SystemTools.ChangeWallpaper", "切换壁纸", "系统个性化"),
             ("SystemTools.SwitchTheme", "切换主题色", "系统个性化"),
+            ("SystemTools.SwitchSystemAccentColor", "切换系统强调色", "系统个性化"),
             ("SystemTools.FullscreenClock", "沉浸式时钟", "其他工具"),
             ("SystemTools.KillProcess", "退出进程", "实用工具"),
             ("SystemTools.ScreenShot", "屏幕截图", "实用工具"),


### PR DESCRIPTION
### Motivation
- 增加允许用户通过颜色板选择并即时切换 Windows 系统强调色的自动化行动以满足自定义主题需求。 
- 修复规则集“正在播放媒体音乐”在 `规则集更新` 触发器下的频繁抖动问题，避免误触发自动化工作流。 
- 使插件中“自动匹配主界面背景色到 ClassIsland 主题”的切换方式与 ClassIsland 的“应用设置->应用主题”路径更一致，避免直接调用主题服务带来的状态不同步。 

### Description
- 新增行动 `SwitchSystemAccentColorAction`（`Actions/SwitchSystemAccentColorAction.cs`）及其设置模型 `AccentColorSettings`（`Settings/AccentColorSettings.cs`）和设置控件 `AccentColorSettingsControl`（`Controls/AccentColorSettingsControl.cs`），通过注册表写入实现即时切换强调色。 
- 在 `Plugin.cs` 中注册新行动并将其加入“系统个性化”菜单和功能开关页（添加动作注册与菜单项）。 
- 修正媒体规则实现（在 `Plugin.cs` 中的 `HandleMediaMusicPlayingRule`）：保持使用 SMTC 遍历会话判断是否存在任意 `Playing` 会话的核心逻辑，同时加入 800ms 短时缓存与异常回退以降低高频触发抖动。 
- 将 `AdaptiveThemeSyncService` 的自动应用主题逻辑改为优先通过反射写入 `SettingsService.Settings.Theme`（方法 `ApplyThemeLikeAppSettings`），无法访问时回退到 `IThemeService.SetTheme(...)`，使行为更接近 ClassIsland 的“应用设置”实现。 

### Testing
- 尝试构建：运行 `dotnet build -v minimal` 但当前运行环境缺少 .NET SDK，构建未能执行（`dotnet: command not found`）。 
- 已运行仓库检查与文本搜索以验证变更点（对文件添加/修改进行了静态检查）；并已提交更改（git 提交成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4422a1c0832b89299cdeadf6fda3)