### PR TITLE
fix: align NextClass display with effective schedule data

### DIFF
--- a/Controls/Components/NextClassDisplayComponent.axaml.cs
+++ b/Controls/Components/NextClassDisplayComponent.axaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using System.Linq;
 using ClassIsland.Shared.ComponentModels;
 using Avalonia.Interactivity;
 using ClassIsland.Core.Abstractions.Controls;
@@ -22,7 +21,6 @@ public partial class NextClassDisplayComponent : ComponentBase<NextClassDisplayS
     private const string NoMoreClassesText = "接下来已无课程";
 
     private readonly ILessonsService _lessonsService;
-    private readonly IProfileService _profileService;
     private readonly IExactTimeService _exactTimeService;
 
     private string _subjectName = string.Empty;
@@ -94,10 +92,9 @@ public partial class NextClassDisplayComponent : ComponentBase<NextClassDisplayS
 
     public new event PropertyChangedEventHandler? PropertyChanged;
 
-    public NextClassDisplayComponent(ILessonsService lessonsService, IProfileService profileService, IExactTimeService exactTimeService)
+    public NextClassDisplayComponent(ILessonsService lessonsService, IExactTimeService exactTimeService)
     {
         _lessonsService = lessonsService;
-        _profileService = profileService;
         _exactTimeService = exactTimeService;
         InitializeComponent();
     }
@@ -140,49 +137,25 @@ public partial class NextClassDisplayComponent : ComponentBase<NextClassDisplayS
 
     private void UpdateDisplay()
     {
-        var classPlan = _lessonsService.CurrentClassPlan;
-        if (classPlan?.TimeLayout == null)
+        var nextSubject = _lessonsService.NextClassSubject;
+        var nextTimeLayoutItem = _lessonsService.NextClassTimeLayoutItem;
+        if (nextSubject == Subject.Fallback || nextTimeLayoutItem.TimeType != 0)
         {
             ApplyNoMoreClasses();
             return;
         }
 
         var now = _exactTimeService.GetCurrentLocalDateTime().TimeOfDay;
-        var validLessonSlots = classPlan.TimeLayout.Layouts
-            .Where(x => x.TimeType == 0)
-            .ToList();
-
-        foreach (var candidateTime in validLessonSlots)
+        if (nextTimeLayoutItem.EndTime < now)
         {
-            if (candidateTime.StartTime <= now)
-            {
-                continue;
-            }
-
-            var candidateClassInfo = classPlan.Classes.FirstOrDefault(x => ReferenceEquals(x.CurrentTimeLayoutItem, candidateTime));
-            if (candidateClassInfo == null)
-            {
-                continue;
-            }
-
-            if (!candidateClassInfo.IsEnabled)
-            {
-                continue;
-            }
-
-            if (!_profileService.Profile.Subjects.TryGetValue(candidateClassInfo.SubjectId, out var subject))
-            {
-                continue;
-            }
-
-            HasNextClass = true;
-            SubjectName = subject.Name;
-            TimeRangeText = $"{candidateTime.StartTime:hh\\:mm}-{candidateTime.EndTime:hh\\:mm}";
-            TeacherName = string.IsNullOrWhiteSpace(subject.TeacherName) ? string.Empty : subject.TeacherName;
+            ApplyNoMoreClasses();
             return;
         }
 
-        ApplyNoMoreClasses();
+        HasNextClass = true;
+        SubjectName = nextSubject.Name;
+        TimeRangeText = $"{nextTimeLayoutItem.StartTime:hh\\:mm}-{nextTimeLayoutItem.EndTime:hh\\:mm}";
+        TeacherName = string.IsNullOrWhiteSpace(nextSubject.TeacherName) ? string.Empty : nextSubject.TeacherName;
     }
 
     private void ApplyNoMoreClasses()

--- a/Controls/Components/NextClassDisplayComponent.axaml.cs
+++ b/Controls/Components/NextClassDisplayComponent.axaml.cs
@@ -21,7 +21,6 @@ public partial class NextClassDisplayComponent : ComponentBase<NextClassDisplayS
     private const string NoMoreClassesText = "接下来已无课程";
 
     private readonly ILessonsService _lessonsService;
-    private readonly IExactTimeService _exactTimeService;
 
     private string _subjectName = string.Empty;
     private string _teacherName = string.Empty;
@@ -92,10 +91,9 @@ public partial class NextClassDisplayComponent : ComponentBase<NextClassDisplayS
 
     public new event PropertyChangedEventHandler? PropertyChanged;
 
-    public NextClassDisplayComponent(ILessonsService lessonsService, IExactTimeService exactTimeService)
+    public NextClassDisplayComponent(ILessonsService lessonsService)
     {
         _lessonsService = lessonsService;
-        _exactTimeService = exactTimeService;
         InitializeComponent();
     }
 
@@ -139,14 +137,7 @@ public partial class NextClassDisplayComponent : ComponentBase<NextClassDisplayS
     {
         var nextSubject = _lessonsService.NextClassSubject;
         var nextTimeLayoutItem = _lessonsService.NextClassTimeLayoutItem;
-        if (nextSubject == Subject.Fallback || nextTimeLayoutItem.TimeType != 0)
-        {
-            ApplyNoMoreClasses();
-            return;
-        }
-
-        var now = _exactTimeService.GetCurrentLocalDateTime().TimeOfDay;
-        if (nextTimeLayoutItem.EndTime < now)
+        if (nextSubject == null || nextTimeLayoutItem == null || nextSubject == Subject.Fallback || nextTimeLayoutItem.TimeType != 0)
         {
             ApplyNoMoreClasses();
             return;


### PR DESCRIPTION
## 问题

`NextClassDisplayComponent` 原先直接读取原始课程配置数据，在「档案设置」中禁用时间线上的下一节课程后，仍会显示这些**未启用的课程**作为“下一节课”，导致组件显示与实际课程表安排不一致。

## 解决策略

重构 `Controls/Components/NextClassDisplayComponent.axaml.cs` 相关逻辑，改为直接依赖 `ILessonsService` 提供的已计算字段：
- `NextClassSubject`
- `NextClassTimeLayoutItem`

这些字段**由 `ILessonsService` 基于当前启用状态、有效课表和时间上下文**计算得出，已经排除未启用课程，确保显示内容准确。同时，复用服务层课表计算逻辑，避免 UI 层重复实现筛选，提升了相关逻辑健壮性。

### 验证

- GitHub Copilot 已在本地构建 `dotnet build -c Release -p:EnableWindowsTargeting=true` 通过，并已执行 `parallel_validation`，确认 CodeQL 扫描无告警和完成 Code Review 反馈处理。
- 我通过在 ClassIsland 2.0.3.2 安装 [GitHub Actions 工作流](https://github.com/yusancky/SystemTools/actions/runs/25564811982) 构建的插件测试，确认在修改课程启用状态时，`NextClass` 组件会立即正确刷新。