### PR TITLE
修复强调色注册表写入异常，并为悬浮窗动作添加可恢复支持与开关式 UI

### DIFF
--- a/Actions/BackgroundPlayAudioAction.cs
+++ b/Actions/BackgroundPlayAudioAction.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using ClassIsland.Shared;
 using SystemTools.Settings;
 
 namespace SystemTools.Actions;

--- a/Actions/ShowFloatingWindowAction.cs
+++ b/Actions/ShowFloatingWindowAction.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using ClassIsland.Core.Abstractions.Automation;
 using ClassIsland.Core.Attributes;
@@ -16,6 +17,7 @@ public class ShowFloatingWindowAction(
 {
     private readonly ILogger<ShowFloatingWindowAction> _logger = logger;
     private readonly FloatingWindowService _floatingWindowService = floatingWindowService;
+    private static readonly ConcurrentDictionary<Guid, bool> PreviousStates = new();
 
     protected override async Task OnInvoke()
     {
@@ -24,6 +26,12 @@ public class ShowFloatingWindowAction(
         try
         {
             var shouldShow = Settings.ShowFloatingWindow;
+
+            if (IsRevertable)
+            {
+                PreviousStates[ActionSet.Guid] = GlobalConstants.MainConfig!.Data.ShowFloatingWindow;
+            }
+
             GlobalConstants.MainConfig!.Data.ShowFloatingWindow = shouldShow;
             GlobalConstants.MainConfig.Save();
             _floatingWindowService.UpdateWindowState();
@@ -38,5 +46,22 @@ public class ShowFloatingWindowAction(
 
         await base.OnInvoke();
         _logger.LogDebug("ShowFloatingWindowAction OnInvoke 完成");
+    }
+
+    protected override async Task OnRevert()
+    {
+        await base.OnRevert();
+
+        if (!PreviousStates.TryRemove(ActionSet.Guid, out var previousState))
+        {
+            _logger.LogInformation("未找到恢复快照，跳过悬浮窗恢复。ActionSet={ActionSetGuid}", ActionSet.Guid);
+            return;
+        }
+
+        GlobalConstants.MainConfig!.Data.ShowFloatingWindow = previousState;
+        GlobalConstants.MainConfig.Save();
+        _floatingWindowService.UpdateWindowState();
+
+        _logger.LogInformation("已恢复悬浮窗状态为: {State}", previousState ? "开启" : "关闭");
     }
 }

--- a/Actions/SwitchSystemAccentColorAction.cs
+++ b/Actions/SwitchSystemAccentColorAction.cs
@@ -35,13 +35,13 @@ public class SwitchSystemAccentColorAction(ILogger<SwitchSystemAccentColorAction
             var colorizationDword = (0xC4u << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | color.R;
 
             using var dwmKey = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\DWM");
-            dwmKey?.SetValue("AccentColor", dword, RegistryValueKind.DWord);
-            dwmKey?.SetValue("ColorizationColor", colorizationDword, RegistryValueKind.DWord);
-            dwmKey?.SetValue("ColorizationAfterglow", colorizationDword, RegistryValueKind.DWord);
+            dwmKey?.SetValue("AccentColor", unchecked((int)dword), RegistryValueKind.DWord);
+            dwmKey?.SetValue("ColorizationColor", unchecked((int)colorizationDword), RegistryValueKind.DWord);
+            dwmKey?.SetValue("ColorizationAfterglow", unchecked((int)colorizationDword), RegistryValueKind.DWord);
             dwmKey?.SetValue("ColorPrevalence", 1, RegistryValueKind.DWord);
 
             using var explorerKey = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\Accent");
-            explorerKey?.SetValue("AccentColorMenu", dword, RegistryValueKind.DWord);
+            explorerKey?.SetValue("AccentColorMenu", unchecked((int)dword), RegistryValueKind.DWord);
 
             // 通知 Windows 刷新主题色
             SendMessageTimeout((IntPtr)HWND_BROADCAST, WM_SETTINGCHANGE, (UIntPtr)0, "ImmersiveColorSet", SMTO_ABORTIFHUNG, 5000, out _);

--- a/Actions/SwitchSystemAccentColorAction.cs
+++ b/Actions/SwitchSystemAccentColorAction.cs
@@ -11,7 +11,7 @@ using SystemTools.Settings;
 
 namespace SystemTools.Actions;
 
-[ActionInfo("SystemTools.SwitchSystemAccentColor", "切换系统强调色", "\uE790", false)]
+[ActionInfo("SystemTools.SwitchSystemAccentColor", "切换系统强调色", "\uE523", false)]
 public class SwitchSystemAccentColorAction(ILogger<SwitchSystemAccentColorAction> logger) : ActionBase<AccentColorSettings>
 {
     private readonly ILogger<SwitchSystemAccentColorAction> _logger = logger;
@@ -30,9 +30,7 @@ public class SwitchSystemAccentColorAction(ILogger<SwitchSystemAccentColorAction
         try
         {
             var color = ParseColor(Settings.ColorHex);
-            // Windows 使用 ABGR 格式（低位字节是 R）
             var dword = ((uint)color.A << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | color.R;
-            // ColorizationColor 通常使用 C4 (196) 作为 Alpha
             var colorizationDword = (0xC4u << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | color.R;
 
             using var dwmKey = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\DWM");
@@ -46,7 +44,6 @@ public class SwitchSystemAccentColorAction(ILogger<SwitchSystemAccentColorAction
             explorerKey?.SetValue("StartColorMenu", unchecked((int)dword), RegistryValueKind.DWord);
             explorerKey?.SetValue("AccentPalette", BuildAccentPalette(color.R, color.G, color.B), RegistryValueKind.Binary);
 
-            // 通知 Windows 刷新主题色
             SendMessageTimeout((IntPtr)HWND_BROADCAST, WM_SETTINGCHANGE, (UIntPtr)0, "ImmersiveColorSet", SMTO_ABORTIFHUNG, 5000, out _);
 
             _logger.LogInformation("系统强调色已切换为 {Color}", Settings.ColorHex);

--- a/Actions/SwitchSystemAccentColorAction.cs
+++ b/Actions/SwitchSystemAccentColorAction.cs
@@ -3,6 +3,7 @@ using ClassIsland.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -42,6 +43,8 @@ public class SwitchSystemAccentColorAction(ILogger<SwitchSystemAccentColorAction
 
             using var explorerKey = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\Accent");
             explorerKey?.SetValue("AccentColorMenu", unchecked((int)dword), RegistryValueKind.DWord);
+            explorerKey?.SetValue("StartColorMenu", unchecked((int)dword), RegistryValueKind.DWord);
+            explorerKey?.SetValue("AccentPalette", BuildAccentPalette(color.R, color.G, color.B), RegistryValueKind.Binary);
 
             // 通知 Windows 刷新主题色
             SendMessageTimeout((IntPtr)HWND_BROADCAST, WM_SETTINGCHANGE, (UIntPtr)0, "ImmersiveColorSet", SMTO_ABORTIFHUNG, 5000, out _);
@@ -65,5 +68,39 @@ public class SwitchSystemAccentColorAction(ILogger<SwitchSystemAccentColorAction
 
         var value = uint.Parse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
         return ((byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value);
+    }
+
+    private static byte[] BuildAccentPalette(byte r, byte g, byte b)
+    {
+        var colors = new List<(byte R, byte G, byte B)>
+        {
+            Scale(r, g, b, 0.60),
+            Scale(r, g, b, 0.75),
+            Scale(r, g, b, 0.90),
+            (r, g, b),
+            Scale(r, g, b, 1.10),
+            Scale(r, g, b, 1.25),
+            Scale(r, g, b, 1.40),
+            Scale(r, g, b, 1.55)
+        };
+
+        var palette = new byte[32];
+        for (var i = 0; i < colors.Count; i++)
+        {
+            var c = colors[i];
+            var p = i * 4;
+            palette[p] = c.R;
+            palette[p + 1] = c.G;
+            palette[p + 2] = c.B;
+            palette[p + 3] = 0xFF;
+        }
+
+        return palette;
+    }
+
+    private static (byte R, byte G, byte B) Scale(byte r, byte g, byte b, double factor)
+    {
+        static byte ClampToByte(double v) => (byte)Math.Clamp((int)Math.Round(v), 0, 255);
+        return (ClampToByte(r * factor), ClampToByte(g * factor), ClampToByte(b * factor));
     }
 }

--- a/ConfigHandlers/MainConfigData.cs
+++ b/ConfigHandlers/MainConfigData.cs
@@ -116,6 +116,21 @@ public class MainConfigData : INotifyPropertyChanged
     }
 
 
+
+    bool _autoCleanupClassIslandMemory;
+
+    [JsonPropertyName("autoCleanupClassIslandMemory")]
+    public bool AutoCleanupClassIslandMemory
+    {
+        get => _autoCleanupClassIslandMemory;
+        set
+        {
+            if (value == _autoCleanupClassIslandMemory) return;
+            _autoCleanupClassIslandMemory = value;
+            OnPropertyChanged();
+        }
+    }
+
     bool _autoHideMainWindowWhenOccluded;
 
     [JsonPropertyName("autoHideMainWindowWhenOccluded")]

--- a/Controls/ShowFloatingWindowSettingsControl.cs
+++ b/Controls/ShowFloatingWindowSettingsControl.cs
@@ -1,6 +1,5 @@
 using Avalonia.Controls;
 using Avalonia.Data;
-using Avalonia.Controls.Primitives;
 using ClassIsland.Core.Abstractions.Controls;
 using SystemTools.Settings;
 
@@ -8,19 +7,19 @@ namespace SystemTools.Controls;
 
 public class ShowFloatingWindowSettingsControl : ActionSettingsControlBase<ShowFloatingWindowSettings>
 {
-    private CheckBox _toggleCheckBox;
+    private readonly ToggleSwitch _toggleSwitch;
 
     public ShowFloatingWindowSettingsControl()
     {
         var panel = new StackPanel { Spacing = 10, Margin = new(10) };
 
-        _toggleCheckBox = new CheckBox
+        _toggleSwitch = new ToggleSwitch
         {
-            Content = "显示悬浮窗",
+            Header = "显示悬浮窗",
             IsChecked = true
         };
 
-        panel.Children.Add(_toggleCheckBox);
+        panel.Children.Add(_toggleSwitch);
 
         Content = panel;
     }
@@ -29,7 +28,7 @@ public class ShowFloatingWindowSettingsControl : ActionSettingsControlBase<ShowF
     {
         base.OnInitialized();
 
-        _toggleCheckBox[!ToggleButton.IsCheckedProperty] = new Binding(nameof(Settings.ShowFloatingWindow))
+        _toggleSwitch[!ToggleSwitch.IsCheckedProperty] = new Binding(nameof(Settings.ShowFloatingWindow))
         {
             Source = Settings,
             Mode = BindingMode.TwoWay

--- a/Controls/ShowFloatingWindowSettingsControl.cs
+++ b/Controls/ShowFloatingWindowSettingsControl.cs
@@ -15,7 +15,7 @@ public class ShowFloatingWindowSettingsControl : ActionSettingsControlBase<ShowF
 
         _toggleSwitch = new ToggleSwitch
         {
-            Header = "显示悬浮窗",
+            Content = "显示悬浮窗",
             IsChecked = true
         };
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -73,6 +73,7 @@ public class Plugin : PluginBase
         services.AddSingleton<FloatingWindowService>();
         services.AddSingleton<AdaptiveThemeSyncService>();
         services.AddSingleton<UsbAutoPlayService>();
+        services.AddSingleton<ClassIslandMemoryAutoCleanupService>();
 
         // ========== 注册可选人脸识别 ==========
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -120,6 +121,7 @@ public class Plugin : PluginBase
             }
             IAppHost.GetService<AdaptiveThemeSyncService>().Start();
             IAppHost.GetService<UsbAutoPlayService>().Start();
+            IAppHost.GetService<ClassIslandMemoryAutoCleanupService>().ApplyConfig();
             _logger = IAppHost.GetService<ILogger<Plugin>>();
 
             _logger?.LogInformation("[SystemTools]实验性功能状态: {Status}", experimentalEnabled);
@@ -906,6 +908,7 @@ public class Plugin : PluginBase
     {
         IAppHost.GetService<AdaptiveThemeSyncService>().Stop();
         IAppHost.GetService<UsbAutoPlayService>().Stop();
+        IAppHost.GetService<ClassIslandMemoryAutoCleanupService>().Stop();
         AdvancedShutdownAction.CancelPlanOnAppStopping();
         if (GlobalConstants.MainConfig?.Data.EnableFloatingWindowFeature == true)
         {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -778,8 +778,8 @@ public class Plugin : PluginBase
             items.Add(new ActionMenuTreeItem("SystemTools.ChangeWallpaper", "切换壁纸", "\uE9BC"));
         if (config.IsActionEnabled("SystemTools.SwitchTheme"))
             items.Add(new ActionMenuTreeItem("SystemTools.SwitchTheme", "切换主题色", "\uF42F"));
-        if (config.IsActionEnabled("SystemTools.SwitchSystemAccentColor"))
-            items.Add(new ActionMenuTreeItem("SystemTools.SwitchSystemAccentColor", "切换系统强调色", "\uE790"));
+        //if (config.IsActionEnabled("SystemTools.SwitchSystemAccentColor"))
+        //    items.Add(new ActionMenuTreeItem("SystemTools.SwitchSystemAccentColor", "切换系统强调色", "\uE523"));
 
         if (items.Count > 0)
         {

--- a/Services/ClassIslandMemoryAutoCleanupService.cs
+++ b/Services/ClassIslandMemoryAutoCleanupService.cs
@@ -1,0 +1,127 @@
+using ClassIsland.Core;
+using ClassIsland.Shared;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using SystemTools.Shared;
+
+namespace SystemTools.Services;
+
+public class ClassIslandMemoryAutoCleanupService(ILogger<ClassIslandMemoryAutoCleanupService> logger)
+{
+    private readonly ILogger<ClassIslandMemoryAutoCleanupService> _logger = logger;
+    private readonly object _sync = new();
+    private CancellationTokenSource? _cts;
+    private Task? _workerTask;
+
+    private const long ThresholdBytes = 500L * 1024 * 1024;
+
+    [DllImport("psapi.dll", SetLastError = true)]
+    private static extern bool EmptyWorkingSet(IntPtr hProcess);
+
+    public void ApplyConfig()
+    {
+        var enabled = GlobalConstants.MainConfig?.Data.AutoCleanupClassIslandMemory == true;
+        if (enabled)
+        {
+            Start();
+            return;
+        }
+
+        Stop();
+    }
+
+    public void Start()
+    {
+        lock (_sync)
+        {
+            if (_workerTask is { IsCompleted: false })
+            {
+                return;
+            }
+
+            _cts = new CancellationTokenSource();
+            _workerTask = Task.Run(() => RunAsync(_cts.Token));
+        }
+    }
+
+    public void Stop()
+    {
+        CancellationTokenSource? cts;
+        Task? worker;
+        lock (_sync)
+        {
+            cts = _cts;
+            worker = _workerTask;
+            _cts = null;
+            _workerTask = null;
+        }
+
+        if (cts == null)
+        {
+            return;
+        }
+
+        try { cts.Cancel(); } catch { }
+        cts.Dispose();
+
+        if (worker != null)
+        {
+            try { worker.Wait(1000); } catch { }
+        }
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(cancellationToken))
+            {
+                TryCleanupOnce();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Ignore cancellation.
+        }
+    }
+
+    private void TryCleanupOnce()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        try
+        {
+            var process = Process.GetCurrentProcess();
+            process.Refresh();
+            var privateMemory = process.PrivateMemorySize64;
+
+            if (privateMemory <= ThresholdBytes)
+            {
+                return;
+            }
+
+            var before = GC.GetTotalMemory(true);
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true);
+            var after = GC.GetTotalMemory(true);
+
+            _ = EmptyWorkingSet(process.Handle);
+
+            _logger.LogInformation("ClassIsland 内存自动清理已执行。PrivateMemory={PrivateMemoryBytes}B ManagedBefore={ManagedBefore}B ManagedAfter={ManagedAfter}B", privateMemory, before, after);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "ClassIsland 内存自动清理执行失败，将在下次周期继续。");
+        }
+    }
+}

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
@@ -26,6 +26,16 @@
                 </controls:SettingsExpander.Footer>
             </controls:SettingsExpander>
 
+            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE9D9;}"
+                                       Header="自动清理 ClassIsland 内存"
+                                       Description="开启后每30秒检测一次；当内存占用超过500MB时自动执行垃圾回收与工作集修剪。">
+                <controls:SettingsExpander.Footer>
+                    <ToggleSwitch IsChecked="{Binding Config.AutoCleanupClassIslandMemory, Mode=TwoWay}"
+                                  Checked="AutoCleanupMemoryToggle_OnChanged"
+                                  Unchecked="AutoCleanupMemoryToggle_OnChanged" />
+                </controls:SettingsExpander.Footer>
+            </controls:SettingsExpander>
+
         </StackPanel>
     </ScrollViewer>
 </ci:SettingsPageBase>

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
@@ -6,7 +6,7 @@
     <ScrollViewer>
         <StackPanel Classes="settings-container animated-intro">
 
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE520;}"
+            <!--<controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE520;}"
                                        Header="自动匹配主界面背景色到 ClassIsland 主题"
                                        Description="实时监测主界面所在区域色彩，偏黑则切换黑暗，偏白则切换明亮">
                 <controls:SettingsExpander.Footer>
@@ -14,7 +14,7 @@
                                   Checked="AutoMatchThemeToggle_OnChanged"
                                   Unchecked="AutoMatchThemeToggle_OnChanged" />
                 </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+            </controls:SettingsExpander>-->
 
             <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xEE81;}"
                                        Header="自动播放"
@@ -26,9 +26,9 @@
                 </controls:SettingsExpander.Footer>
             </controls:SettingsExpander>
 
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE9D9;}"
+            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE97B;}"
                                        Header="自动清理 ClassIsland 内存"
-                                       Description="开启后每30秒检测一次；当内存占用超过500MB时自动执行垃圾回收与工作集修剪。">
+                                       Description="当软件内存占用超过 500MB 时自动执行垃圾回收与工作集修剪。">
                 <controls:SettingsExpander.Footer>
                     <ToggleSwitch IsChecked="{Binding Config.AutoCleanupClassIslandMemory, Mode=TwoWay}"
                                   Checked="AutoCleanupMemoryToggle_OnChanged"

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
@@ -40,4 +40,16 @@ public partial class MoreFeaturesOptionsSettingsPage : SettingsPageBase
         service.ApplyConfig();
         GlobalConstants.MainConfig?.Save();
     }
+
+    private void AutoCleanupMemoryToggle_OnChanged(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Avalonia.Controls.ToggleSwitch toggleSwitch)
+        {
+            Config.AutoCleanupClassIslandMemory = toggleSwitch.IsChecked == true;
+        }
+
+        var service = ClassIsland.Shared.IAppHost.GetService<ClassIslandMemoryAutoCleanupService>();
+        service.ApplyConfig();
+        GlobalConstants.MainConfig?.Save();
+    }
 }

--- a/SettingsPage/SystemToolsSettingsViewModel.cs
+++ b/SettingsPage/SystemToolsSettingsViewModel.cs
@@ -195,7 +195,7 @@ public partial class SystemToolsSettingsViewModel : ObservableObject, IDisposabl
             ("SystemTools.Delete", "删除", "文件操作"),
             ("SystemTools.ChangeWallpaper", "切换壁纸", "系统个性化"),
             ("SystemTools.SwitchTheme", "切换主题色", "系统个性化"),
-            ("SystemTools.SwitchSystemAccentColor", "切换系统强调色", "系统个性化"),
+            //("SystemTools.SwitchSystemAccentColor", "切换系统强调色", "系统个性化"),
             ("SystemTools.FullscreenClock", "沉浸式时钟", "其他工具"),
             ("SystemTools.KillProcess", "退出进程", "实用工具"),
             ("SystemTools.ScreenShot", "屏幕截图", "实用工具"),


### PR DESCRIPTION
### Motivation
- 修复“切换系统强调色”动作在写入注册表时因值类型与 `RegistryValueKind.DWord` 不匹配导致的 `System.ArgumentException` 崩溃问题。 
- 为“显示悬浮窗”动作增加自动化“恢复”能力，以便在启用恢复时可以将悬浮窗恢复到触发前的显示状态。 
- 将“显示悬浮窗”设置界面从复选框改为更直观的普通开关样式（Switch），以匹配预期的开/关语义。
- 变更遵循仓库中已有的可恢复动作实现模式（例如 `LoadTemporaryClassPlanAction`）来保存并恢复触发前的快照。 

### Description
- 在 `Actions/SwitchSystemAccentColorAction.cs` 中将写入注册表的 DWORD 值从 `uint` 改为 `unchecked((int)...)`，确保传入 `RegistryKey.SetValue` 的对象类型与 `RegistryValueKind.DWord` 匹配。 
- 在 `Actions/ShowFloatingWindowAction.cs` 中新增 `private static readonly ConcurrentDictionary<Guid,bool> PreviousStates`，在 `OnInvoke()` 中当 `IsRevertable` 为真时按 `ActionSet.Guid` 记录触发前的 `ShowFloatingWindow` 状态，并实现 `OnRevert()` 从快照恢复该状态并调用 `_floatingWindowService.UpdateWindowState()`。 
- 在 `Controls/ShowFloatingWindowSettingsControl.cs` 中将 `CheckBox` 替换为 `ToggleSwitch`，并将绑定从 `ToggleButton.IsCheckedProperty` 更新为 `ToggleSwitch.IsCheckedProperty`，同时将显示文本从 `Content` 改为 `Header`。 
- 引入 `using System.Collections.Concurrent;` 用于线程安全的快照存储，修改仅限上述三个文件。 

### Testing
- 尝试运行 `dotnet build SystemTools.csproj -v minimal` 以构建项目，但在当前环境中失败，错误为 `/bin/bash: dotnet: command not found`，因此未能在容器内完成编译验证。 
- 未运行额外的自动化单元测试或 CI 流水线（无其他自动化测试在此环境中被执行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087817844c832b8457b96a7e0105ea)