### PR TITLE
Adapt SystemTools for ClassIsland misha-alpha (Avalonia12 / net10 / apiVersion 2.2)

### DIFF
--- a/Actions/AdvancedShutdownAction.cs
+++ b/Actions/AdvancedShutdownAction.cs
@@ -454,7 +454,7 @@ public class AdvancedShutdownAction(ILogger<AdvancedShutdownAction> logger) : Ac
             CanResize = false,
             Topmost = true,
             ShowInTaskbar = false,
-            SystemDecorations = SystemDecorations.None,
+            WindowDecorations = WindowDecorations.None,
             Background = Brushes.Transparent, 
             TransparencyLevelHint = [WindowTransparencyLevel.Transparent],
             Content = new Border

--- a/Controls/AdjustScreenBrightnessSettingsControl.cs
+++ b/Controls/AdjustScreenBrightnessSettingsControl.cs
@@ -53,10 +53,10 @@ public class AdjustScreenBrightnessSettingsControl : ActionSettingsControlBase<A
     {
         base.OnInitialized();
 
-        _brightnessInput[!NumericUpDown.ValueProperty] = new Binding(nameof(Settings.BrightnessPercent))
+        _brightnessInput.Bind(NumericUpDown.ValueProperty, new Binding(nameof(Settings.BrightnessPercent))
         {
             Source = Settings,
             Mode = BindingMode.TwoWay
-        };
+        });
     }
 }

--- a/Controls/Components/BetterCarouselContainerSettingsControl.axaml
+++ b/Controls/Components/BetterCarouselContainerSettingsControl.axaml
@@ -1,4 +1,4 @@
-﻿<ci:ComponentBase
+<ci:ComponentBase
     x:Class="SystemTools.Controls.Components.BetterCarouselContainerSettingsControl"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -21,10 +21,10 @@
         DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:BetterCarouselContainerSettingsControl}}">
         <ScrollViewer>
             <StackPanel>
-                <controls:SettingsExpander Header="轮换模式"
+                <controls:FASettingsExpander Header="轮换模式"
                                            Description="设定容器轮换组件的顺序行为"
                                            IconSource="{ci:FluentIconSource &#xEFCD;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <ComboBox Width="140"
                                   SelectedItem="{Binding Settings.RotationMode, Mode=TwoWay}"
                                   ItemsSource="{Binding RotationModes}">
@@ -34,21 +34,21 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander Header="启用动画"
+                <controls:FASettingsExpander Header="启用动画"
                                            Description="启用后，在轮换组件时播放过渡动画"
                                            IconSource="{ci:FluentIconSource &#xEDC1;}"
                                            IsExpanded="True">
-                    <controls:SettingsExpander.Footer>
-                        <ToggleSwitch IsChecked="{Binding Settings.IsAnimationEnabled, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                    <controls:SettingsExpanderItem Content="动画样式"
+                    <controls:FASettingsExpander.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding Settings.IsAnimationEnabled, Mode=TwoWay}" />
+                    </controls:FASettingsExpander.Footer>
+                    <controls:FASettingsExpanderItem Content="动画样式"
                                                    Description="切换组件时使用的动画样式"
                                                    IconSource="{ci:FluentIconSource &#xF06B;}"
                                                    IsVisible="{Binding Settings.IsAnimationEnabled}">
-                        <controls:SettingsExpanderItem.Footer>
+                        <controls:FASettingsExpanderItem.Footer>
                             <ComboBox Width="140"
                                       SelectedItem="{Binding Settings.AnimationStyle, Mode=TwoWay}"
                                       ItemsSource="{Binding AnimationStyles}">
@@ -58,16 +58,16 @@
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
-                        </controls:SettingsExpanderItem.Footer>
-                    </controls:SettingsExpanderItem>
-                </controls:SettingsExpander>
+                        </controls:FASettingsExpanderItem.Footer>
+                    </controls:FASettingsExpanderItem>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander Header="显示进度条"
+                <controls:FASettingsExpander Header="显示进度条"
                                            Description="显示当前组件剩余显示时长的进度条"
                                            IconSource="{ci:FluentIconSource &#xE093;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <ToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}" />
+                            <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}" />
                             <ComboBox Width="140"
                                       IsVisible="{Binding Settings.ShowProgressBar}"
                                       SelectedItem="{Binding Settings.ProgressBarPosition, Mode=TwoWay}"
@@ -79,27 +79,27 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                         </StackPanel>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander Header="降低进度条精度"
+                <controls:FASettingsExpander Header="降低进度条精度"
                                            Description="开启后进度条每秒刷新一次，降低刷新频率"
                                            IconSource="{ci:FluentIconSource &#xEDC1;}"
                                            IsVisible="{Binding Settings.ShowProgressBar}">
-                    <controls:SettingsExpander.Footer>
-                        <ToggleSwitch IsChecked="{Binding Settings.ReduceProgressBarPrecision, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    <controls:FASettingsExpander.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding Settings.ReduceProgressBarPrecision, Mode=TwoWay}" />
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander Header="添加分隔符样式"
+                <controls:FASettingsExpander Header="添加分隔符样式"
                                            Description="在容器左右两侧固定显示“&lt;”和“&gt;”"
                                            IconSource="{ci:FluentIconSource &#xEEDF;}">
-                    <controls:SettingsExpander.Footer>
-                        <ToggleSwitch IsChecked="{Binding Settings.ShowSideSeparators, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    <controls:FASettingsExpander.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowSideSeparators, Mode=TwoWay}" />
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander Header="设置组件显示时长"
+                <controls:FASettingsExpander Header="设置组件显示时长"
                                            Description="分别设置每个组件的显示秒数"
                                            IconSource="{ci:FluentIconSource &#xF361;}"
                                            IsExpanded="True">
@@ -134,7 +134,7 @@
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
                     </StackPanel>
-                </controls:SettingsExpander>
+                </controls:FASettingsExpander>
                 <Label HorizontalAlignment="Center"
                        Foreground="{DynamicResource MaterialDesignBodyLight}">
                     Added by SystemTools

--- a/Controls/Components/BetterCarouselContainerSettingsControl.axaml
+++ b/Controls/Components/BetterCarouselContainerSettingsControl.axaml
@@ -42,7 +42,7 @@
                                            IconSource="{ci:FluentIconSource &#xEDC1;}"
                                            IsExpanded="True">
                     <controls:FASettingsExpander.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding Settings.IsAnimationEnabled, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding Settings.IsAnimationEnabled, Mode=TwoWay}" />
                     </controls:FASettingsExpander.Footer>
                     <controls:FASettingsExpanderItem Content="动画样式"
                                                    Description="切换组件时使用的动画样式"
@@ -67,7 +67,7 @@
                                            IconSource="{ci:FluentIconSource &#xE093;}">
                     <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}" />
+                            <ToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}" />
                             <ComboBox Width="140"
                                       IsVisible="{Binding Settings.ShowProgressBar}"
                                       SelectedItem="{Binding Settings.ProgressBarPosition, Mode=TwoWay}"
@@ -87,7 +87,7 @@
                                            IconSource="{ci:FluentIconSource &#xEDC1;}"
                                            IsVisible="{Binding Settings.ShowProgressBar}">
                     <controls:FASettingsExpander.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding Settings.ReduceProgressBarPrecision, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding Settings.ReduceProgressBarPrecision, Mode=TwoWay}" />
                     </controls:FASettingsExpander.Footer>
                 </controls:FASettingsExpander>
 
@@ -95,7 +95,7 @@
                                            Description="在容器左右两侧固定显示“&lt;”和“&gt;”"
                                            IconSource="{ci:FluentIconSource &#xEEDF;}">
                     <controls:FASettingsExpander.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowSideSeparators, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding Settings.ShowSideSeparators, Mode=TwoWay}" />
                     </controls:FASettingsExpander.Footer>
                 </controls:FASettingsExpander>
 

--- a/Controls/Components/ClipboardContentComponent.axaml.cs
+++ b/Controls/Components/ClipboardContentComponent.axaml.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using SystemTools.Models.ComponentSettings;
 using RoutedEventArgs = Avalonia.Interactivity.RoutedEventArgs;
 
@@ -93,7 +94,7 @@ public partial class ClipboardContentComponent : ComponentBase<ClipboardContentS
                 return;
             }
 
-            var text = await clipboard.GetTextAsync();
+            var text = await ClipboardExtensions.TryGetTextAsync(clipboard);
             if (text == _lastClipboardText)
             {
                 return;

--- a/Controls/Components/LocalQuoteSettingsControl.axaml
+++ b/Controls/Components/LocalQuoteSettingsControl.axaml
@@ -19,11 +19,11 @@
     <Grid DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:LocalQuoteSettingsControl}}">
         <ScrollViewer>
             <StackPanel>
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="选择 txt 文件"
                     Description="每行一句，自动忽略空行"
                     IconSource="{ci:FluentIconSource &#xE6FD;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
                             <TextBox Grid.Column="0"
                                      MinWidth="220"
@@ -32,35 +32,35 @@
                                     Content="浏览"
                                     Click="BrowseQuotesFileButton_OnClick" />
                         </Grid>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="启用动画"
                     Description="切换句子时使用翻页动画"
                     IconSource="{ci:FluentIconSource &#xF001;}">
-                    <controls:SettingsExpander.Footer>
-                        <ToggleSwitch IsChecked="{Binding Settings.EnableAnimation, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    <controls:FASettingsExpander.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding Settings.EnableAnimation, Mode=TwoWay}" />
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="轮播间隔（秒）"
                     Description="每次切换到下一句的时间间隔"
                     IconSource="{ci:FluentIconSource &#xEF75;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <NumericUpDown Minimum="1"
                                        Maximum="8000"
                                        Increment="1"
                                        Value="{Binding Settings.CarouselIntervalSeconds, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="轮播顺序"
                     Description="设置一言文本的轮播方式"
                     IconSource="{ci:FluentIconSource &#xE143;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <ComboBox SelectedItem="{Binding Settings.PlaybackOrder, Mode=TwoWay}"
                                   ItemsSource="{Binding PlaybackOrders}">
                             <ComboBox.ItemTemplate>
@@ -69,25 +69,25 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
                 
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="记忆轮播行"
                     Description="重启软件后从上次的位置和剩余时间继续"
                     IconSource="{ci:FluentIconSource &#xF35B;}">
-                    <controls:SettingsExpander.Footer>
-                        <ToggleSwitch IsChecked="{Binding Settings.IsPersistenceEnabled, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    <controls:FASettingsExpander.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding Settings.IsPersistenceEnabled, Mode=TwoWay}" />
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="显示进度条"
                     Description="显示当前句子剩余显示时长的进度条"
                     IconSource="{ci:FluentIconSource &#xE093;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <ToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}" />
+                            <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}" />
                             <ComboBox Width="140"
                                       IsVisible="{Binding Settings.ShowProgressBar}"
                                       SelectedItem="{Binding Settings.ProgressBarPosition, Mode=TwoWay}"
@@ -99,8 +99,8 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                         </StackPanel>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
 
                 <Label HorizontalAlignment="Center"

--- a/Controls/Components/LocalQuoteSettingsControl.axaml
+++ b/Controls/Components/LocalQuoteSettingsControl.axaml
@@ -40,7 +40,7 @@
                     Description="切换句子时使用翻页动画"
                     IconSource="{ci:FluentIconSource &#xF001;}">
                     <controls:FASettingsExpander.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding Settings.EnableAnimation, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding Settings.EnableAnimation, Mode=TwoWay}" />
                     </controls:FASettingsExpander.Footer>
                 </controls:FASettingsExpander>
 
@@ -77,7 +77,7 @@
                     Description="重启软件后从上次的位置和剩余时间继续"
                     IconSource="{ci:FluentIconSource &#xF35B;}">
                     <controls:FASettingsExpander.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding Settings.IsPersistenceEnabled, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding Settings.IsPersistenceEnabled, Mode=TwoWay}" />
                     </controls:FASettingsExpander.Footer>
                 </controls:FASettingsExpander>
 
@@ -87,7 +87,7 @@
                     IconSource="{ci:FluentIconSource &#xE093;}">
                     <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}" />
+                            <ToggleSwitch IsChecked="{Binding Settings.ShowProgressBar, Mode=TwoWay}" />
                             <ComboBox Width="140"
                                       IsVisible="{Binding Settings.ShowProgressBar}"
                                       SelectedItem="{Binding Settings.ProgressBarPosition, Mode=TwoWay}"

--- a/Controls/Components/LyricsDisplaySettingsControl.axaml
+++ b/Controls/Components/LyricsDisplaySettingsControl.axaml
@@ -84,7 +84,7 @@
                     <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal">
                             <controls1:ExperimentalBadge IsVisible="{Binding Settings.IsExperimentalModeActivated}" />
-                        <controls:FAToggleSwitch IsChecked="{Binding Settings.KeepLyricsWindowBottom, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding Settings.KeepLyricsWindowBottom, Mode=TwoWay}" />
                         </StackPanel>
                     </controls:FASettingsExpander.Footer>
                 </controls:FASettingsExpander>

--- a/Controls/Components/LyricsDisplaySettingsControl.axaml
+++ b/Controls/Components/LyricsDisplaySettingsControl.axaml
@@ -1,4 +1,4 @@
-﻿<ci:ComponentBase
+<ci:ComponentBase
     x:Class="SystemTools.Controls.Components.LyricsDisplaySettingsControl"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -13,24 +13,25 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     x:TypeArguments="settings:LyricsDisplaySettings"
-    mc:Ignorable="d">
+    x:CompileBindings="False"
+                     mc:Ignorable="d">
     <Grid
         DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:LyricsDisplaySettingsControl}}">
         <ScrollViewer>
             <StackPanel>
                 <!-- 警告信息 -->
-                <controls:InfoBar IsOpen="True"
+                <controls:FAInfoBar IsOpen="True"
                                   IsClosable="True"
                                   Severity="Warning"
                                   Margin="0,0,0,12"
                                   Message="使用前请确保音乐软件已启用桌面歌词显示（横排/单行/关闭翻译）且不贴近屏幕上侧边缘&#x0A;您可通过调整桌面歌词的 长/宽 和下方的 缩放设置 以达到最佳效果（一般需手动缩短桌面歌词长度）&#x0A;不建议使用组件宽度限制，这可能会导致歌词显示不完整" />
 
                 <!-- 音乐软件选择 -->
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="选择音乐软件"
                     Description="选择要显示歌词的音乐软件"
                     IconSource="{ci:FluentIconSource &#xE342;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <ComboBox MinWidth="150"
                                   SelectedIndex="{Binding Settings.SelectedMusicSoftware, Mode=TwoWay}"
                                   SelectionChanged="MusicSoftwareComboBox_SelectionChanged">
@@ -42,51 +43,51 @@
                             <ComboBoxItem IsEnabled="False" Foreground="Gray">酷我音乐(将不会适配)</ComboBoxItem>
                             <ComboBoxItem IsEnabled="False" Foreground="Gray">Apple Music(将不会适配)</ComboBoxItem>
                         </ComboBox>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="歌词显示缩放"
                     Description="调整歌词显示大小比例"
                     Margin="0,6,0,0"
                     IconSource="{ci:FluentIconSource &#xE10B;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <Slider MinWidth="150"
                                 Minimum="0.3"
                                 Maximum="3.0"
                                 TickFrequency="0.1"
                                 Value="{Binding Settings.ImageScale, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
                 <!-- 歌词刷新率设置 -->
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="歌词刷新率"
                     Description="对于配置较低电脑建议提高数值，但会导致歌词显示延迟；建议100；重启 ClassIsland 以应用该设置"
                     Margin="0,6,0,0"
                     IconSource="{ci:FluentIconSource &#xE8E1;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <NumericUpDown MinWidth="100"
                                        Minimum="25"
                                        Maximum="1000"
                                        Increment="25"
                                        Value="{Binding Settings.RefreshRate, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
                 <!-- 保持歌词窗口置底 -->
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="保持歌词窗口置底"
                     Description="强制将歌词窗口置底（每80ms/暂不适用网易云音乐）;请在上侧调整好样式再使用此功能！"
                     Margin="0,6,0,0"
                     IconSource="{ci:FluentIconSource &#xF4AB;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal">
                             <controls1:ExperimentalBadge IsVisible="{Binding Settings.IsExperimentalModeActivated}" />
-                        <ToggleSwitch IsChecked="{Binding Settings.KeepLyricsWindowBottom, Mode=TwoWay}" />
+                        <controls:FAToggleSwitch IsChecked="{Binding Settings.KeepLyricsWindowBottom, Mode=TwoWay}" />
                         </StackPanel>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
                 <Label HorizontalAlignment="Center"
                        Foreground="{DynamicResource MaterialDesignBodyLight}">

--- a/Controls/Components/LyricsDisplaySettingsControl.axaml.cs
+++ b/Controls/Components/LyricsDisplaySettingsControl.axaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Avalonia.Controls;
 using Avalonia.Threading;
 using ClassIsland.Core.Abstractions.Controls;
@@ -38,24 +38,24 @@ public partial class LyricsDisplaySettingsControl : ComponentBase<LyricsDisplayS
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel == null) return;
 
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Title = "帮助",
                 Content = "     在使用适配 Lyricify Lite 的功能前，强烈建议您阅读相关使用方法！        \n\n     点击“不再提示”后您仍可以在本插件“关于”页面查看相关帮助。",
                 PrimaryButtonText = "前往了解…",
                 CloseButtonText = "以后再说",
                 SecondaryButtonText = "关闭并不再显示",
-                DefaultButton = ContentDialogButton.Primary
+                DefaultButton = FAContentDialogButton.Primary
             };
 
             var result = await dialog.ShowAsync(topLevel);
 
-            if (result == ContentDialogResult.Secondary && GlobalConstants.MainConfig != null)
+            if (result == FAContentDialogResult.Secondary && GlobalConstants.MainConfig != null)
             {
                 GlobalConstants.MainConfig.Data.LyricifyLiteWarningDismissed = true;
                 GlobalConstants.MainConfig.Save();
             }
-            else if (result == ContentDialogResult.Primary)
+            else if (result == FAContentDialogResult.Primary)
             {
                 OpenLyricifyLiteReadme();
             }
@@ -96,12 +96,12 @@ public partial class LyricsDisplaySettingsControl : ComponentBase<LyricsDisplayS
                 Width = 550
             };
 
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Title = "Lyricify Lite 适配帮助",
                 Content = border,
                 PrimaryButtonText = "了解",
-                DefaultButton = ContentDialogButton.Primary
+                DefaultButton = FAContentDialogButton.Primary
             };
 
             await dialog.ShowAsync(topLevel);
@@ -120,12 +120,12 @@ public partial class LyricsDisplaySettingsControl : ComponentBase<LyricsDisplayS
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel == null) return;
 
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Title = title,
                 Content = message,
                 PrimaryButtonText = "了解",
-                DefaultButton = ContentDialogButton.Primary
+                DefaultButton = FAContentDialogButton.Primary
             };
 
             await dialog.ShowAsync(topLevel);

--- a/Controls/Components/NetworkStatusSettingsControl.axaml
+++ b/Controls/Components/NetworkStatusSettingsControl.axaml
@@ -1,4 +1,4 @@
-﻿<ci:ComponentBase
+<ci:ComponentBase
     x:Class="SystemTools.Controls.Components.NetworkStatusSettingsControl"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -21,20 +21,20 @@
         <ScrollViewer>
             <StackPanel>
 
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="延迟检测网址"
                     Description="要检测的网址,默认 https://baidu.com"
                     IconSource="{ci:FluentIconSource &#xEAB6;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <TextBox MinWidth="200"
                                  Text="{Binding Settings.PingUrl, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Description="选择网络延迟检测方式"
                     IconSource="{ci:FluentIconSource &#xE923;}">
-                    <controls:SettingsExpander.Header>
+                    <controls:FASettingsExpander.Header>
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <TextBlock Text="检测模式" 
                                        VerticalAlignment="Center"/>
@@ -47,9 +47,9 @@
                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
                             </Button>
                         </StackPanel>
-                    </controls:SettingsExpander.Header>
+                    </controls:FASettingsExpander.Header>
     
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <ComboBox MinWidth="120"
                                   SelectedItem="{Binding Settings.DetectMode, Mode=TwoWay}">
                             <ComboBox.Items>
@@ -63,18 +63,18 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander
+                <controls:FASettingsExpander
                     Header="前缀文本内容"
                     Description="显示在延迟数值前的前缀文字"
                     IconSource="{ci:FluentIconSource &#xF171;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <TextBox MinWidth="150"
                                  Text="{Binding Settings.DisplayText, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
                 <Label HorizontalAlignment="Center"
                        Foreground="{DynamicResource MaterialDesignBodyLight}">

--- a/Controls/Components/NextClassDisplaySettingsControl.axaml
+++ b/Controls/Components/NextClassDisplaySettingsControl.axaml
@@ -15,30 +15,30 @@
     <Grid DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:NextClassDisplaySettingsControl}}">
         <ScrollViewer>
             <StackPanel>
-                <controls:SettingsExpander Header="前缀文本"
+                <controls:FASettingsExpander Header="前缀文本"
                                           Description="显示在课程名前的前缀文本"
                                           IconSource="{ci:FluentIconSource &#xF171;}">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <TextBox MinWidth="220"
                                  Text="{Binding Settings.PrefixText, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
                 
-                <controls:SettingsExpander Header="显示时间段"
+                <controls:FASettingsExpander Header="显示时间段"
                                            Description="开启后会显示对应课程时间段"
                                            IconSource="{ci:FluentIconSource &#xF361;}">
-                    <controls:SettingsExpander.Footer>
-                        <ToggleSwitch IsChecked="{Binding Settings.ShowTimeRange, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    <controls:FASettingsExpander.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowTimeRange, Mode=TwoWay}" />
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander Header="显示任教老师"
+                <controls:FASettingsExpander Header="显示任教老师"
                                           Description="开启后会显示任教老师姓名"
                                           IconSource="{ci:FluentIconSource &#xED4F;}">
-                    <controls:SettingsExpander.Footer>
-                        <ToggleSwitch IsChecked="{Binding Settings.ShowTeacherName, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    <controls:FASettingsExpander.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowTeacherName, Mode=TwoWay}" />
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
                 <Label HorizontalAlignment="Center"
                        Foreground="{DynamicResource MaterialDesignBodyLight}">

--- a/Controls/Components/NextClassDisplaySettingsControl.axaml
+++ b/Controls/Components/NextClassDisplaySettingsControl.axaml
@@ -28,7 +28,7 @@
                                            Description="开启后会显示对应课程时间段"
                                            IconSource="{ci:FluentIconSource &#xF361;}">
                     <controls:FASettingsExpander.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowTimeRange, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding Settings.ShowTimeRange, Mode=TwoWay}" />
                     </controls:FASettingsExpander.Footer>
                 </controls:FASettingsExpander>
 
@@ -36,7 +36,7 @@
                                           Description="开启后会显示任教老师姓名"
                                           IconSource="{ci:FluentIconSource &#xED4F;}">
                     <controls:FASettingsExpander.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowTeacherName, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding Settings.ShowTeacherName, Mode=TwoWay}" />
                     </controls:FASettingsExpander.Footer>
                 </controls:FASettingsExpander>
 

--- a/Controls/Components/ScrollingTextSettingsControl.axaml
+++ b/Controls/Components/ScrollingTextSettingsControl.axaml
@@ -11,37 +11,37 @@
     <Grid DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:ScrollingTextSettingsControl}}">
         <ScrollViewer>
             <StackPanel>
-                <controls:SettingsExpander Header="显示文本设置" 
+                <controls:FASettingsExpander Header="显示文本设置" 
                                            IconSource="{ci:FluentIconSource &#xEEDF;}"
                                            Description="设置显示文本">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <TextBox Width="250" Text="{Binding Settings.TextContent, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander Header="组件长度" 
+                <controls:FASettingsExpander Header="组件长度" 
                                            IconSource="{ci:FluentIconSource &#xE093;}"
                                            Description="设置固定显示宽度；仅当宽度小于文字长度时开始滚动">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <NumericUpDown Minimum="100" Maximum="2000" Value="{Binding Settings.ComponentWidth, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander Header="滚动速度" 
+                <controls:FASettingsExpander Header="滚动速度" 
                                            IconSource="{ci:FluentIconSource &#xE8E1;}"
                                            Description="数值越大滚动速度越快">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <NumericUpDown Minimum="10" Maximum="500" Value="{Binding Settings.ScrollSpeed, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <!--<controls:SettingsExpander Header="启用边框动画"
+                <!--<controls:FASettingsExpander Header="启用边框动画"
                                            IconSource="{ci:FluentIconSource &#xE093;}"
                                            Description="启用后">
-                    <controls:SettingsExpander.Footer>
-                        <ToggleSwitch IsChecked="{Binding Settings.ShowBorder, Mode=TwoWay}" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>-->
+                    <controls:FASettingsExpander.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding Settings.ShowBorder, Mode=TwoWay}" />
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>-->
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/Controls/DisableDeviceSettingsControl.cs
+++ b/Controls/DisableDeviceSettingsControl.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Data;
 using ClassIsland.Core.Abstractions.Controls;
 using SystemTools.Settings;
@@ -40,9 +40,9 @@ public class DisableDeviceSettingsControl : ActionSettingsControlBase<DisableDev
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        _deviceIdBox[!TextBox.TextProperty] = new Binding(nameof(Settings.DeviceId))
+        _deviceIdBox.Bind(TextBox.TextProperty, new Binding(nameof(Settings.DeviceId))
         {
             Source = Settings
-        };
+        });
     }
 }

--- a/Controls/EnableDeviceSettingsControl.cs
+++ b/Controls/EnableDeviceSettingsControl.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Data;
 using ClassIsland.Core.Abstractions.Controls;
 using SystemTools.Settings;
@@ -40,9 +40,9 @@ public class EnableDeviceSettingsControl : ActionSettingsControlBase<EnableDevic
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        _deviceIdBox[!TextBox.TextProperty] = new Binding(nameof(Settings.DeviceId))
+        _deviceIdBox.Bind(TextBox.TextProperty, new Binding(nameof(Settings.DeviceId))
         {
             Source = Settings
-        };
+        });
     }
 }

--- a/Controls/HotkeyRecorderControl.cs
+++ b/Controls/HotkeyRecorderControl.cs
@@ -1,11 +1,10 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Layout;
 using Avalonia.VisualTree;
 using System;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.TrayNotify;
 
 namespace SystemTools.Controls;
 
@@ -64,7 +63,7 @@ public class HotkeyRecorderControl : Border
         };
 
         // 绑定文字
-        _displayText.Bind(TextBlock.TextProperty, this.GetObservable(HotkeyDisplayProperty).ToBinding());
+        _displayText.Bind(TextBlock.TextProperty, this.GetObservable(HotkeyDisplayProperty));
 
         // 设置内容
         Child = _displayText;

--- a/Controls/KillProcessSettingsControl.cs
+++ b/Controls/KillProcessSettingsControl.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
@@ -79,10 +79,10 @@ public class KillProcessSettingsControl : ActionSettingsControlBase<KillProcessS
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        _processNameBox[!TextBox.TextProperty] = new Avalonia.Data.Binding(nameof(Settings.ProcessName))
+        _processNameBox.Bind(TextBox.TextProperty, new Avalonia.Data.Binding(nameof(Settings.ProcessName))
         {
             Source = Settings
-        };
+        });
     }
 
     private async Task ShowProcessList()

--- a/Controls/KillProcessSettingsControl.cs
+++ b/Controls/KillProcessSettingsControl.cs
@@ -6,6 +6,7 @@ using ClassIsland.Core.Abstractions.Controls;
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Avalonia.Input.Platform;
 using SystemTools.Settings;
 
 namespace SystemTools.Controls;

--- a/Controls/ProcessRunningRuleSettingsControl.cs
+++ b/Controls/ProcessRunningRuleSettingsControl.cs
@@ -5,6 +5,7 @@ using ClassIsland.Core.Abstractions.Controls;
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Avalonia.Input.Platform;
 using SystemTools.Rules;
 
 namespace SystemTools.Controls;

--- a/Controls/SetVolumeSettingsControl.cs
+++ b/Controls/SetVolumeSettingsControl.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Data;
 using ClassIsland.Core.Abstractions.Controls;
 using SystemTools.Actions;
@@ -45,10 +45,10 @@ public class SetVolumeSettingsControl : ActionSettingsControlBase<SetVolumeSetti
     {
         base.OnInitialized();
 
-        _volumeInput[!NumericUpDown.ValueProperty] = new Binding(nameof(Settings.VolumePercent))
+        _volumeInput.Bind(NumericUpDown.ValueProperty, new Binding(nameof(Settings.VolumePercent))
         {
             Source = Settings,
             Mode = BindingMode.TwoWay
-        };
+        });
     }
 }

--- a/Controls/ShowFloatingWindowSettingsControl.cs
+++ b/Controls/ShowFloatingWindowSettingsControl.cs
@@ -28,10 +28,10 @@ public class ShowFloatingWindowSettingsControl : ActionSettingsControlBase<ShowF
     {
         base.OnInitialized();
 
-        _toggleSwitch[!ToggleSwitch.IsCheckedProperty] = new Binding(nameof(Settings.ShowFloatingWindow))
+        _toggleSwitch.Bind(ToggleSwitch.IsCheckedProperty, new Binding(nameof(Settings.ShowFloatingWindow))
         {
             Source = Settings,
             Mode = BindingMode.TwoWay
-        };
+        });
     }
 }

--- a/Controls/ShowFloatingWindowSettingsControl.cs
+++ b/Controls/ShowFloatingWindowSettingsControl.cs
@@ -1,19 +1,20 @@
 using Avalonia.Controls;
 using Avalonia.Data;
 using ClassIsland.Core.Abstractions.Controls;
+using FluentAvalonia.UI.Controls;
 using SystemTools.Settings;
 
 namespace SystemTools.Controls;
 
 public class ShowFloatingWindowSettingsControl : ActionSettingsControlBase<ShowFloatingWindowSettings>
 {
-    private readonly ToggleSwitch _toggleSwitch;
+    private readonly FAToggleSwitch _toggleSwitch;
 
     public ShowFloatingWindowSettingsControl()
     {
         var panel = new StackPanel { Spacing = 10, Margin = new(10) };
 
-        _toggleSwitch = new ToggleSwitch
+        _toggleSwitch = new FAToggleSwitch
         {
             Content = "显示悬浮窗",
             IsChecked = true
@@ -28,7 +29,7 @@ public class ShowFloatingWindowSettingsControl : ActionSettingsControlBase<ShowF
     {
         base.OnInitialized();
 
-        _toggleSwitch.Bind(ToggleSwitch.IsCheckedProperty, new Binding(nameof(Settings.ShowFloatingWindow))
+        _toggleSwitch.Bind(FAToggleSwitch.IsCheckedProperty, new Binding(nameof(Settings.ShowFloatingWindow))
         {
             Source = Settings,
             Mode = BindingMode.TwoWay

--- a/Controls/ShowFloatingWindowSettingsControl.cs
+++ b/Controls/ShowFloatingWindowSettingsControl.cs
@@ -8,13 +8,13 @@ namespace SystemTools.Controls;
 
 public class ShowFloatingWindowSettingsControl : ActionSettingsControlBase<ShowFloatingWindowSettings>
 {
-    private readonly FAToggleSwitch _toggleSwitch;
+    private readonly ToggleSwitch _toggleSwitch;
 
     public ShowFloatingWindowSettingsControl()
     {
         var panel = new StackPanel { Spacing = 10, Margin = new(10) };
 
-        _toggleSwitch = new FAToggleSwitch
+        _toggleSwitch = new ToggleSwitch
         {
             Content = "显示悬浮窗",
             IsChecked = true
@@ -29,7 +29,7 @@ public class ShowFloatingWindowSettingsControl : ActionSettingsControlBase<ShowF
     {
         base.OnInitialized();
 
-        _toggleSwitch.Bind(FAToggleSwitch.IsCheckedProperty, new Binding(nameof(Settings.ShowFloatingWindow))
+        _toggleSwitch.Bind(ToggleSwitch.IsCheckedProperty, new Binding(nameof(Settings.ShowFloatingWindow))
         {
             Source = Settings,
             Mode = BindingMode.TwoWay

--- a/Controls/ShowToastSettingsControl.cs
+++ b/Controls/ShowToastSettingsControl.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Data;
 using ClassIsland.Core.Abstractions.Controls;
 using SystemTools.Settings;
@@ -50,16 +50,16 @@ public class ShowToastSettingsControl : ActionSettingsControlBase<ShowToastSetti
     {
         base.OnInitialized();
 
-        _titleBox[!TextBox.TextProperty] = new Binding(nameof(Settings.Title))
+        _titleBox.Bind(TextBox.TextProperty, new Binding(nameof(Settings.Title))
         {
             Source = Settings,
             Mode = BindingMode.TwoWay
-        };
+        });
 
-        _contentBox[!TextBox.TextProperty] = new Binding(nameof(Settings.Content))
+        _contentBox.Bind(TextBox.TextProperty, new Binding(nameof(Settings.Content))
         {
             Source = Settings,
             Mode = BindingMode.TwoWay
-        };
+        });
     }
 }

--- a/Controls/TriggerCustomTriggerSettingsControl.cs
+++ b/Controls/TriggerCustomTriggerSettingsControl.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Data;
 using ClassIsland.Core.Abstractions.Controls;
 using SystemTools.Settings;
@@ -47,9 +47,9 @@ public class TriggerCustomTriggerSettingsControl : ActionSettingsControlBase<Tri
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        _triggerIdTextBox[!TextBox.TextProperty] = new Binding(nameof(Settings.TriggerId))
+        _triggerIdTextBox.Bind(TextBox.TextProperty, new Binding(nameof(Settings.TriggerId))
         {
             Source = Settings
-        };
+        });
     }
 }

--- a/Controls/TypeContentSettingsControl.cs
+++ b/Controls/TypeContentSettingsControl.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Data;
 using ClassIsland.Core.Abstractions.Controls;
 using SystemTools.Settings;
@@ -33,9 +33,9 @@ public class TypeContentSettingsControl : ActionSettingsControlBase<TypeContentS
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        _textBox[!TextBox.TextProperty] = new Binding(nameof(Settings.Content))
+        _textBox.Bind(TextBox.TextProperty, new Binding(nameof(Settings.Content))
         {
             Source = Settings
-        };
+        });
     }
 }

--- a/Services/FloatingWindowService.cs
+++ b/Services/FloatingWindowService.cs
@@ -308,7 +308,7 @@ public class FloatingWindowService
             Height = 64,
             ShowActivated = false,
             Topmost = _configHandler.Data.FloatingWindowLayer == 1,
-            SystemDecorations = SystemDecorations.None,
+            WindowDecorations = WindowDecorations.None,
             Background = Brushes.Transparent,
             CanResize = false,
             ShowInTaskbar = false,

--- a/Settings/FloatingWindowTriggerSettings.cs
+++ b/Settings/FloatingWindowTriggerSettings.cs
@@ -25,7 +25,7 @@ public class FloatingWindowTriggerSettings : TriggerSettingsControlBase<Floating
     private readonly TextBox _nameTextBox;
     private readonly List<string> _iconTokens = new();
 
-    private ContentDialog? _iconPickerDialog;
+    private FAContentDialog? _iconPickerDialog;
 
     public FloatingWindowTriggerSettings()
     {
@@ -88,11 +88,11 @@ public class FloatingWindowTriggerSettings : TriggerSettingsControlBase<Floating
         EnsureIconsLoaded();
         var rows = BuildVirtualizedRows(460);
 
-        _iconPickerDialog = new ContentDialog
+        _iconPickerDialog = new FAContentDialog
         {
             Title = "选择悬浮窗图标",
             PrimaryButtonText = "关闭",
-            DefaultButton = ContentDialogButton.Primary,
+            DefaultButton = FAContentDialogButton.Primary,
             Content = BuildIconPickerContent(rows)
         };
 

--- a/SettingsPage/AboutSettingsPage.axaml
+++ b/SettingsPage/AboutSettingsPage.axaml
@@ -1,4 +1,4 @@
-﻿<ci:SettingsPageBase x:Class="SystemTools.AboutSettingsPage"
+<ci:SettingsPageBase x:Class="SystemTools.AboutSettingsPage"
                      xmlns="https://github.com/avaloniaui"
                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -7,6 +7,7 @@
                      xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
                      xmlns:mdxaml="https://github.com/whistyun/Markdown.Avalonia"
                      xmlns:helpers="clr-namespace:ClassIsland.Core.Helpers;assembly=ClassIsland.Core"
+                     x:CompileBindings="False"
                      mc:Ignorable="d"
                      d:DesignHeight="450"
                      d:DesignWidth="800">
@@ -29,7 +30,7 @@
 
             <!-- 信息卡片 -->
             <Border ClipToBounds="True" CornerRadius="4" Margin="0,0,0,12">
-                <controls:SettingsExpanderItem>
+                <controls:FASettingsExpanderItem>
                     <Grid HorizontalAlignment="Stretch" Margin="12">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -95,7 +96,7 @@
                             </Button>
                         </StackPanel>
                     </Grid>
-                </controls:SettingsExpanderItem>
+                </controls:FASettingsExpanderItem>
             </Border>
 
             <!-- 标签页 -->
@@ -123,34 +124,34 @@
                     <Border Grid.Row="1" BorderThickness="0">
                         <StackPanel>
                             <StackPanel IsVisible="{Binding IsHelpTab}">
-                                <controls:SettingsExpander Header="Lyricify Lite 适配帮助"
+                                <controls:FASettingsExpander Header="Lyricify Lite 适配帮助"
                                                            Description="点击查看 Lyricify Lite 适配说明"
                                                            IconSource="{ci:FluentIconSource &#xE236;}"
                                                            Click="OnLyricifyLiteHelpClick"
                                                            HorizontalAlignment="Stretch"
                                                            ActionIconSource="{ci:FluentIconSource &#xEC2E;} "
                                                            IsClickEnabled="True"/>
-                                <controls:SettingsExpander Header="反馈渠道" IconSource="{ci:FluentIconSource &#xE3F6;}"
+                                <controls:FASettingsExpander Header="反馈渠道" IconSource="{ci:FluentIconSource &#xE3F6;}"
                                                             IsExpanded="True">
-                                    <controls:SettingsExpanderItem
+                                    <controls:FASettingsExpanderItem
                                         Click="UriNavigationCommands_OnClick"
                                         CommandParameter="https://github.com/Programmer-MrWang/SystemTools/issues/new"
                                         Content="问题反馈/功能建议"
                                         ActionIconSource="{ci:FluentIconSource &#xEC2E;} "
                                         IsClickEnabled="True"/>
-                                    <controls:SettingsExpanderItem
+                                    <controls:FASettingsExpanderItem
                                         Click="UriNavigationCommands_OnClick"
                                         CommandParameter="https://v.wjx.cn/vm/rjA0NBq.aspx#"
                                         Content="调研问卷"
                                         ActionIconSource="{ci:FluentIconSource &#xEC2E;} "
                                         IsClickEnabled="True"/>
-                                    <controls:SettingsExpanderItem
+                                    <controls:FASettingsExpanderItem
                                         Click="UriNavigationCommands_OnClick"
                                         CommandParameter="https://qm.qq.com/q/fEUW3A9zR6"
                                         Content="插件社群"
                                         ActionIconSource="{ci:FluentIconSource &#xEC2E;} "
                                         IsClickEnabled="True"/>
-                                </controls:SettingsExpander>
+                                </controls:FASettingsExpander>
                             </StackPanel>
 
                             <mdxaml:MarkdownScrollViewer 

--- a/SettingsPage/AboutSettingsPage.axaml.cs
+++ b/SettingsPage/AboutSettingsPage.axaml.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media.Imaging;
 using ClassIsland.Core.Abstractions.Controls;
@@ -88,24 +88,24 @@ public partial class AboutSettingsPage : SettingsPageBase
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel == null) return;
 
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Title = "帮助",
                 Content = "     在使用适配 Lyricify Lite 的功能前，强烈建议您阅读相关使用方法！        \n\n     点击“不再提示”后您仍可以在本插件“关于”页面查看相关帮助。",
                 PrimaryButtonText = "前往了解…",
                 CloseButtonText = "以后再说",
                 SecondaryButtonText = "关闭并不再显示",
-                DefaultButton = ContentDialogButton.Primary
+                DefaultButton = FAContentDialogButton.Primary
             };
 
             var result = await dialog.ShowAsync(topLevel);
 
-            if (result == ContentDialogResult.Secondary && GlobalConstants.MainConfig != null)
+            if (result == FAContentDialogResult.Secondary && GlobalConstants.MainConfig != null)
             {
                 GlobalConstants.MainConfig.Data.LyricifyLiteWarningDismissed = true;
                 GlobalConstants.MainConfig.Save();
             }
-            else if (result == ContentDialogResult.Primary)
+            else if (result == FAContentDialogResult.Primary)
             {
                 OpenLyricifyLiteReadme();
             }
@@ -146,12 +146,12 @@ public partial class AboutSettingsPage : SettingsPageBase
                 Width = 550
             };
 
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Title = "Lyricify Lite 适配帮助",
                 Content = border,
                 PrimaryButtonText = "了解",
-                DefaultButton = ContentDialogButton.Primary
+                DefaultButton = FAContentDialogButton.Primary
             };
 
             await dialog.ShowAsync(topLevel);
@@ -170,12 +170,12 @@ public partial class AboutSettingsPage : SettingsPageBase
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel == null) return;
 
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Title = title,
                 Content = message,
                 PrimaryButtonText = "了解",
-                DefaultButton = ContentDialogButton.Primary
+                DefaultButton = FAContentDialogButton.Primary
             };
 
             await dialog.ShowAsync(topLevel);

--- a/SettingsPage/AboutSettingsPage.axaml.cs
+++ b/SettingsPage/AboutSettingsPage.axaml.cs
@@ -37,7 +37,7 @@ public partial class AboutSettingsPage : SettingsPageBase
     {
         var url = e.Source switch
         {
-            SettingsExpanderItem s => s.CommandParameter?.ToString(),
+            FASettingsExpanderItem s => s.CommandParameter?.ToString(),
             Button s => s.CommandParameter?.ToString(),
             _ => "classisland://app/test/"
         };

--- a/SettingsPage/FloatingWindowEditorSettingsPage.axaml
+++ b/SettingsPage/FloatingWindowEditorSettingsPage.axaml
@@ -8,6 +8,7 @@
                      xmlns:controls1="clr-namespace:SystemTools.Controls"
                      xmlns:ruleset="clr-namespace:ClassIsland.Core.Controls.Ruleset;assembly=ClassIsland.Core"
                      xmlns:local="clr-namespace:SystemTools"
+                     x:CompileBindings="False"
                      mc:Ignorable="d"
                      d:DesignHeight="800"
                      d:DesignWidth="800">
@@ -54,7 +55,7 @@
                                 Theme="{StaticResource TransparentButton}" />
                     </StackPanel>
                 </ci:Field>
-                <ToggleSwitch Grid.Column="1"
+                <controls:FAToggleSwitch Grid.Column="1"
                               OnContent="显示" OffContent="隐藏"
                               IsChecked="{Binding ViewModel.Settings.ShowFloatingWindow, Mode=OneWay}"
                               IsEnabled="{Binding ViewModel.HasFloatingTriggerEntries}"
@@ -63,7 +64,7 @@
             </Grid>
 
             <!-- ===== 按钮布局区域 ===== -->
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xEA37;}"
+            <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xEA37;}"
                                        Header="悬浮窗按钮布局"
                                        Description="您可在下方通过拖拽调整行内按钮顺序，或添加行以实现纵列排布等功能"
                                        IsExpanded="True">
@@ -183,18 +184,18 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
-            </controls:SettingsExpander>
+            </controls:FASettingsExpander>
 
             <!-- 外观设置 -->
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE51E;}"
+            <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xE51E;}"
                                        Header="外观设置"
                                        Description="设置悬浮窗外观"
                                        IsExpanded="False">
 
-                <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xE10B;}"
+                <controls:FASettingsExpanderItem IconSource="{ci:FluentIconSource &#xE10B;}"
                                                Content="悬浮窗缩放"
                                                Description="调整悬浮窗缩放大小">
-                    <controls:SettingsExpanderItem.Footer>
+                    <controls:FASettingsExpanderItem.Footer>
                         <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                             <Slider Width="160"
                                     Minimum="0.5"
@@ -208,13 +209,13 @@
                                 Width="46"
                                 VerticalAlignment="Center" />
                         </StackPanel>
-                    </controls:SettingsExpanderItem.Footer>
-                </controls:SettingsExpanderItem>
+                    </controls:FASettingsExpanderItem.Footer>
+                </controls:FASettingsExpanderItem>
 
-                <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xE721;}"
+                <controls:FASettingsExpanderItem IconSource="{ci:FluentIconSource &#xE721;}"
                                                Content="图标大小"
                                                Description="调整悬浮窗内图标缩放">
-                    <controls:SettingsExpanderItem.Footer>
+                    <controls:FASettingsExpanderItem.Footer>
                         <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                             <Slider Width="160"
                                     Minimum="15"
@@ -228,13 +229,13 @@
                                 Width="46"
                                 VerticalAlignment="Center" />
                         </StackPanel>
-                    </controls:SettingsExpanderItem.Footer>
-                </controls:SettingsExpanderItem>
+                    </controls:FASettingsExpanderItem.Footer>
+                </controls:FASettingsExpanderItem>
 
-                <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xF26F;}"
+                <controls:FASettingsExpanderItem IconSource="{ci:FluentIconSource &#xF26F;}"
                                                Content="文字大小"
                                                Description="调整悬浮窗内文字缩放">
-                    <controls:SettingsExpanderItem.Footer>
+                    <controls:FASettingsExpanderItem.Footer>
                         <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                             <Slider Width="160"
                                     Minimum="8"
@@ -248,13 +249,13 @@
                                 Width="46"
                                 VerticalAlignment="Center" />
                         </StackPanel>
-                    </controls:SettingsExpanderItem.Footer>
-                </controls:SettingsExpanderItem>
+                    </controls:FASettingsExpanderItem.Footer>
+                </controls:FASettingsExpanderItem>
 
-                <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xE772;}"
+                <controls:FASettingsExpanderItem IconSource="{ci:FluentIconSource &#xE772;}"
                                                Content="透明度"
                                                Description="调整悬浮窗透明度">
-                    <controls:SettingsExpanderItem.Footer>
+                    <controls:FASettingsExpanderItem.Footer>
                         <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                             <Slider Width="160"
                                     Minimum="10"
@@ -267,13 +268,13 @@
                                        Width="46"
                                        VerticalAlignment="Center" />
                         </StackPanel>
-                    </controls:SettingsExpanderItem.Footer>
-                </controls:SettingsExpanderItem>
+                    </controls:FASettingsExpanderItem.Footer>
+                </controls:FASettingsExpanderItem>
 
-                <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xE5CB;}"
+                <controls:FASettingsExpanderItem IconSource="{ci:FluentIconSource &#xE5CB;}"
                                                Content="主题"
                                                Description="设置悬浮窗主题">
-                    <controls:SettingsExpanderItem.Footer>
+                    <controls:FASettingsExpanderItem.Footer>
                         <ComboBox SelectedIndex="{Binding ViewModel.Settings.FloatingWindowTheme, Mode=TwoWay}">
                             <ComboBoxItem>
                                 <ci:IconText Glyph="&#xE5CB;" Text="跟随ClassIsland" />
@@ -285,32 +286,32 @@
                                 <ci:IconText Glyph="&#xF44B;" Text="黑暗" />
                             </ComboBoxItem>
                         </ComboBox>
-                    </controls:SettingsExpanderItem.Footer>
-                </controls:SettingsExpanderItem>
+                    </controls:FASettingsExpanderItem.Footer>
+                </controls:FASettingsExpanderItem>
 
-                <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xE20B;}"
+                <controls:FASettingsExpanderItem IconSource="{ci:FluentIconSource &#xE20B;}"
                                                Content="阴影效果"
                                                Description="悬浮窗阴影效果">
-                    <controls:SettingsExpanderItem.Footer>
-                        <ToggleSwitch IsChecked="{Binding ViewModel.Settings.FloatingWindowShadowEnabled, Mode=TwoWay}" />
-                    </controls:SettingsExpanderItem.Footer>
-                </controls:SettingsExpanderItem>
+                    <controls:FASettingsExpanderItem.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding ViewModel.Settings.FloatingWindowShadowEnabled, Mode=TwoWay}" />
+                    </controls:FASettingsExpanderItem.Footer>
+                </controls:FASettingsExpanderItem>
 
-                <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xE7C3;}"
+                <controls:FASettingsExpanderItem IconSource="{ci:FluentIconSource &#xE7C3;}"
                                                Content="一直显示拖动把手"
                                                Description="即使未检测到触摸设备也显示拖动把手">
-                    <controls:SettingsExpanderItem.Footer>
-                        <ToggleSwitch IsChecked="{Binding ViewModel.Settings.FloatingWindowDragHandleAlwaysVisible, Mode=TwoWay}" />
-                    </controls:SettingsExpanderItem.Footer>
-                </controls:SettingsExpanderItem>
-            </controls:SettingsExpander>
+                    <controls:FASettingsExpanderItem.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding ViewModel.Settings.FloatingWindowDragHandleAlwaysVisible, Mode=TwoWay}" />
+                    </controls:FASettingsExpanderItem.Footer>
+                </controls:FASettingsExpanderItem>
+            </controls:FASettingsExpander>
 
             <!-- 层级设置 -->
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xEA2F;}"
+            <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xEA2F;}"
                                        Header="悬浮窗层级"
                                        Description="悬浮窗在屏幕上的层级。置底则会显示在所有窗口的后方，置顶则将显示在所有窗口的前方。"
                                        IsExpanded="False">
-                <controls:SettingsExpander.Footer>
+                <controls:FASettingsExpander.Footer>
                     <ComboBox SelectedIndex="{Binding ViewModel.Settings.FloatingWindowLayer, Mode=TwoWay}">
                         <ComboBoxItem>
                             <ci:IconText Glyph="&#xE0CB;" Text="置底" />
@@ -319,11 +320,11 @@
                             <ci:IconText Glyph="&#xE197;" Text="置顶" />
                         </ComboBoxItem>
                     </ComboBox>
-                </controls:SettingsExpander.Footer>
-                <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xE125;}"
+                </controls:FASettingsExpander.Footer>
+                <controls:FASettingsExpanderItem IconSource="{ci:FluentIconSource &#xE125;}"
                                                Content="层级设置频率"
                                                Description="在什么时候重新设置悬浮窗层级。请注意，较高的频率可能会产生较高的性能占用并导致悬浮窗闪烁。">
-                    <controls:SettingsExpanderItem.Footer>
+                    <controls:FASettingsExpanderItem.Footer>
                         <ComboBox
                             SelectedIndex="{Binding ViewModel.Settings.FloatingWindowLayerRecheckMode, Mode=TwoWay}">
                             <ComboBoxItem>窗口层级变化时</ComboBoxItem>
@@ -351,15 +352,15 @@
                                 </StackPanel>
                             </ComboBoxItem>
                         </ComboBox>
-                    </controls:SettingsExpanderItem.Footer>
-                </controls:SettingsExpanderItem>
-            </controls:SettingsExpander>
+                    </controls:FASettingsExpanderItem.Footer>
+                </controls:FASettingsExpanderItem>
+            </controls:FASettingsExpander>
 
             <!-- 规则集设置（全局设置，不随方案切换） -->
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xEFBF;}"
+            <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xEFBF;}"
                                        Header="按规则隐藏"
                                        Description="在指定规则满足时，自动隐藏悬浮窗。此为全局设置，不随配置方案切换。">
-                <controls:SettingsExpander.Footer>
+                <controls:FASettingsExpander.Footer>
                     <StackPanel Orientation="Horizontal">
                         <Button HorizontalAlignment="Left"
                                 Theme="{StaticResource TransparentButton}"
@@ -367,12 +368,12 @@
                                 IsVisible="{Binding ViewModel.Settings.FloatingWindowRulesetEnabled}">
                             <ci:IconText Glyph="&#xF17E;" Text="编辑规则集…" />
                         </Button>
-                        <ToggleSwitch VerticalAlignment="Center"
+                        <controls:FAToggleSwitch VerticalAlignment="Center"
                                       OnContent="启用" OffContent="禁用"
                                       IsChecked="{Binding ViewModel.Settings.FloatingWindowRulesetEnabled}" />
                     </StackPanel>
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>
 
             <TextBlock Text="Programmer_Wang ©2026"
                        Foreground="Gray"

--- a/SettingsPage/FloatingWindowEditorSettingsPage.axaml
+++ b/SettingsPage/FloatingWindowEditorSettingsPage.axaml
@@ -55,7 +55,7 @@
                                 Theme="{StaticResource TransparentButton}" />
                     </StackPanel>
                 </ci:Field>
-                <controls:FAToggleSwitch Grid.Column="1"
+                <ToggleSwitch Grid.Column="1"
                               OnContent="显示" OffContent="隐藏"
                               IsChecked="{Binding ViewModel.Settings.ShowFloatingWindow, Mode=OneWay}"
                               IsEnabled="{Binding ViewModel.HasFloatingTriggerEntries}"
@@ -293,7 +293,7 @@
                                                Content="阴影效果"
                                                Description="悬浮窗阴影效果">
                     <controls:FASettingsExpanderItem.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding ViewModel.Settings.FloatingWindowShadowEnabled, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding ViewModel.Settings.FloatingWindowShadowEnabled, Mode=TwoWay}" />
                     </controls:FASettingsExpanderItem.Footer>
                 </controls:FASettingsExpanderItem>
 
@@ -301,7 +301,7 @@
                                                Content="一直显示拖动把手"
                                                Description="即使未检测到触摸设备也显示拖动把手">
                     <controls:FASettingsExpanderItem.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding ViewModel.Settings.FloatingWindowDragHandleAlwaysVisible, Mode=TwoWay}" />
+                        <ToggleSwitch IsChecked="{Binding ViewModel.Settings.FloatingWindowDragHandleAlwaysVisible, Mode=TwoWay}" />
                     </controls:FASettingsExpanderItem.Footer>
                 </controls:FASettingsExpanderItem>
             </controls:FASettingsExpander>
@@ -368,7 +368,7 @@
                                 IsVisible="{Binding ViewModel.Settings.FloatingWindowRulesetEnabled}">
                             <ci:IconText Glyph="&#xF17E;" Text="编辑规则集…" />
                         </Button>
-                        <controls:FAToggleSwitch VerticalAlignment="Center"
+                        <ToggleSwitch VerticalAlignment="Center"
                                       OnContent="启用" OffContent="禁用"
                                       IsChecked="{Binding ViewModel.Settings.FloatingWindowRulesetEnabled}" />
                     </StackPanel>

--- a/SettingsPage/FloatingWindowEditorSettingsPage.axaml.cs
+++ b/SettingsPage/FloatingWindowEditorSettingsPage.axaml.cs
@@ -29,7 +29,7 @@ using SystemTools.Shared;
 namespace SystemTools;
 
 [HidePageTitle]
-[SettingsPageInfo("systemtools.settings.floating", "悬浮窗编辑", "\uEA37", "\uEA37")]
+[SettingsPageInfo("systemtools.settings.floating", "悬浮窗编辑", "", "")]
 public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
 {
     public FloatingWindowEditorSettingsPage()
@@ -61,6 +61,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
 
     private Point? _floatingDragStartPoint;
     private Border? _floatingDragSourceBorder;
+    private PointerPressedEventArgs? _floatingDragPressedArgs;
 
     // ===== 规则集 Drawer 状态 =====
     private enum RulesetTargetType { Button, Row, Window }
@@ -68,8 +69,8 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
     private FloatingTriggerItem? _currentButtonTarget;
     private FloatingTriggerRow? _currentRowTarget;
 
-    private FAToggleSwitch? _drawerIsVisibleToggle;
-    private FAToggleSwitch? _drawerHideOnRuleToggle;
+    private ToggleSwitch? _drawerIsVisibleToggle;
+    private ToggleSwitch? _drawerHideOnRuleToggle;
     private RulesetControl? _drawerRulesetControl;
 
     private Ruleset? _currentDrawerRuleset;
@@ -181,7 +182,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
 
     private void OnFloatingWindowVisibleToggleChanged(object? sender, RoutedEventArgs e)
     {
-        if (sender is not FAToggleSwitch toggle)
+        if (sender is not ToggleSwitch toggle)
         {
             return;
         }
@@ -329,7 +330,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
             Margin = new Thickness(22, 0, 0, -15)
         };
 
-        _drawerIsVisibleToggle = new FAToggleSwitch
+        _drawerIsVisibleToggle = new ToggleSwitch
         {
             OnContent = "显示",
             OffContent = "隐藏",
@@ -339,7 +340,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
         ToolTip.SetTip(_drawerIsVisibleToggle, "控制此项目是否显示");
         _drawerIsVisibleToggle.IsCheckedChanged += OnDrawerIsVisibleChanged;
 
-        _drawerHideOnRuleToggle = new FAToggleSwitch
+        _drawerHideOnRuleToggle = new ToggleSwitch
         {
             OnContent = "按规则隐藏",
             OffContent = "禁用规则",
@@ -600,6 +601,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
 
         _floatingDragSourceBorder = border;
         _floatingDragStartPoint = e.GetPosition(border);
+        _floatingDragPressedArgs = e;
         // 主动 capture，避免鼠标移出 Border 后丢失 PointerMoved/PointerReleased
         e.Pointer.Capture(border);
         e.Handled = e.Pointer.Type is PointerType.Touch or PointerType.Pen;
@@ -613,6 +615,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
         }
         _floatingDragSourceBorder = null;
         _floatingDragStartPoint = null;
+        _floatingDragPressedArgs = null;
     }
 
     private async void OnFloatingTriggerItemPointerMoved(object? sender, PointerEventArgs e)
@@ -638,25 +641,30 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
             return;
         }
 
+        if (_floatingDragPressedArgs == null)
+        {
+            return;
+        }
+
         var data = new DataTransfer();
-        data.SetData("FloatingTriggerButtonId", buttonId);
+        var format = DataFormat.CreateStringApplicationFormat("FloatingTriggerButtonId");
+        data.Add(DataTransferItem.Create(format, buttonId));
 
         _floatingDragSourceBorder = null;
         _floatingDragStartPoint = null;
         var isTouchOrPen = e.Pointer.Type is PointerType.Touch or PointerType.Pen;
-        await e.DoDragDrop(data, DragDropEffects.Move);
+        await DragDrop.DoDragDropAsync(_floatingDragPressedArgs, data, DragDropEffects.Move);
+        _floatingDragPressedArgs = null;
         e.Handled = isTouchOrPen;
     }
 
     private static bool TryGetDragButtonId(DragEventArgs e, out string buttonId)
     {
         buttonId = string.Empty;
-        if (!e.DataTransfer.Contains("FloatingTriggerButtonId"))
-        {
+        var format = DataFormat.CreateStringApplicationFormat("FloatingTriggerButtonId");
+        if (!e.DataTransfer.Formats.Contains(format))
             return false;
-        }
-
-        buttonId = e.DataTransfer.Get("FloatingTriggerButtonId") as string ?? string.Empty;
+        buttonId = e.DataTransfer.TryGetText() ?? string.Empty;
         return !string.IsNullOrWhiteSpace(buttonId);
     }
 

--- a/SettingsPage/FloatingWindowEditorSettingsPage.axaml.cs
+++ b/SettingsPage/FloatingWindowEditorSettingsPage.axaml.cs
@@ -68,8 +68,8 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
     private FloatingTriggerItem? _currentButtonTarget;
     private FloatingTriggerRow? _currentRowTarget;
 
-    private ToggleSwitch? _drawerIsVisibleToggle;
-    private ToggleSwitch? _drawerHideOnRuleToggle;
+    private FAToggleSwitch? _drawerIsVisibleToggle;
+    private FAToggleSwitch? _drawerHideOnRuleToggle;
     private RulesetControl? _drawerRulesetControl;
 
     private Ruleset? _currentDrawerRuleset;
@@ -181,7 +181,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
 
     private void OnFloatingWindowVisibleToggleChanged(object? sender, RoutedEventArgs e)
     {
-        if (sender is not ToggleSwitch toggle)
+        if (sender is not FAToggleSwitch toggle)
         {
             return;
         }
@@ -214,10 +214,10 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
     private async void OnAddFloatingWindowProfileClick(object? sender, RoutedEventArgs e)
     {
         var textBox = new TextBox { Text = "" };
-        var dialogResult = await new ContentDialog
+        var dialogResult = await new FAContentDialog
         {
             Title = "新建悬浮窗配置方案",
-            DefaultButton = ContentDialogButton.Primary,
+            DefaultButton = FAContentDialogButton.Primary,
             PrimaryButtonText = "创建",
             SecondaryButtonText = "取消",
             Content = new Field
@@ -228,7 +228,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
             }
         }.ShowAsync();
 
-        if (dialogResult != ContentDialogResult.Primary)
+        if (dialogResult != FAContentDialogResult.Primary)
         {
             return;
         }
@@ -329,7 +329,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
             Margin = new Thickness(22, 0, 0, -15)
         };
 
-        _drawerIsVisibleToggle = new ToggleSwitch
+        _drawerIsVisibleToggle = new FAToggleSwitch
         {
             OnContent = "显示",
             OffContent = "隐藏",
@@ -339,7 +339,7 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
         ToolTip.SetTip(_drawerIsVisibleToggle, "控制此项目是否显示");
         _drawerIsVisibleToggle.IsCheckedChanged += OnDrawerIsVisibleChanged;
 
-        _drawerHideOnRuleToggle = new ToggleSwitch
+        _drawerHideOnRuleToggle = new FAToggleSwitch
         {
             OnContent = "按规则隐藏",
             OffContent = "禁用规则",
@@ -638,25 +638,25 @@ public partial class FloatingWindowEditorSettingsPage : SettingsPageBase
             return;
         }
 
-        var data = new DataObject();
-        data.Set("FloatingTriggerButtonId", buttonId);
+        var data = new DataTransfer();
+        data.SetData("FloatingTriggerButtonId", buttonId);
 
         _floatingDragSourceBorder = null;
         _floatingDragStartPoint = null;
         var isTouchOrPen = e.Pointer.Type is PointerType.Touch or PointerType.Pen;
-        await DragDrop.DoDragDrop(e, data, DragDropEffects.Move);
+        await e.DoDragDrop(data, DragDropEffects.Move);
         e.Handled = isTouchOrPen;
     }
 
     private static bool TryGetDragButtonId(DragEventArgs e, out string buttonId)
     {
         buttonId = string.Empty;
-        if (!e.Data.Contains("FloatingTriggerButtonId"))
+        if (!e.DataTransfer.Contains("FloatingTriggerButtonId"))
         {
             return false;
         }
 
-        buttonId = e.Data.Get("FloatingTriggerButtonId") as string ?? string.Empty;
+        buttonId = e.DataTransfer.Get("FloatingTriggerButtonId") as string ?? string.Empty;
         return !string.IsNullOrWhiteSpace(buttonId);
     }
 

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
@@ -21,9 +21,8 @@
                                        Header="自动播放"
                                        Description="当插入U盘设备时时自动打开">
                 <controls:FASettingsExpander.Footer>
-                    <controls:FAToggleSwitch IsChecked="{Binding Config.AutoOpenUsbDriveOnInsert, Mode=TwoWay}"
-                                  Checked="AutoOpenUsbToggle_OnChanged"
-                                  Unchecked="AutoOpenUsbToggle_OnChanged" />
+                    <ToggleSwitch IsChecked="{Binding Config.AutoOpenUsbDriveOnInsert, Mode=TwoWay}"
+                                  IsCheckedChanged="AutoOpenUsbToggle_OnChanged" />
                 </controls:FASettingsExpander.Footer>
             </controls:FASettingsExpander>
 
@@ -31,9 +30,8 @@
                                        Header="自动清理 ClassIsland 内存"
                                        Description="当软件内存占用超过 500MB 时自动执行垃圾回收与工作集修剪。">
                 <controls:FASettingsExpander.Footer>
-                    <controls:FAToggleSwitch IsChecked="{Binding Config.AutoCleanupClassIslandMemory, Mode=TwoWay}"
-                                  Checked="AutoCleanupMemoryToggle_OnChanged"
-                                  Unchecked="AutoCleanupMemoryToggle_OnChanged" />
+                    <ToggleSwitch IsChecked="{Binding Config.AutoCleanupClassIslandMemory, Mode=TwoWay}"
+                                  IsCheckedChanged="AutoCleanupMemoryToggle_OnChanged" />
                 </controls:FASettingsExpander.Footer>
             </controls:FASettingsExpander>
 

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml
@@ -2,39 +2,40 @@
                      xmlns="https://github.com/avaloniaui"
                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                      xmlns:ci="http://classisland.tech/schemas/xaml/core"
-                     xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia">
+                     xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+                     x:CompileBindings="False">
     <ScrollViewer>
         <StackPanel Classes="settings-container animated-intro">
 
-            <!--<controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE520;}"
+            <!--<controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xE520;}"
                                        Header="自动匹配主界面背景色到 ClassIsland 主题"
                                        Description="实时监测主界面所在区域色彩，偏黑则切换黑暗，偏白则切换明亮">
-                <controls:SettingsExpander.Footer>
-                    <ToggleSwitch IsChecked="{Binding Config.AutoMatchMainBackgroundTheme, Mode=TwoWay}"
+                <controls:FASettingsExpander.Footer>
+                    <controls:FAToggleSwitch IsChecked="{Binding Config.AutoMatchMainBackgroundTheme, Mode=TwoWay}"
                                   Checked="AutoMatchThemeToggle_OnChanged"
                                   Unchecked="AutoMatchThemeToggle_OnChanged" />
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>-->
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>-->
 
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xEE81;}"
+            <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xEE81;}"
                                        Header="自动播放"
                                        Description="当插入U盘设备时时自动打开">
-                <controls:SettingsExpander.Footer>
-                    <ToggleSwitch IsChecked="{Binding Config.AutoOpenUsbDriveOnInsert, Mode=TwoWay}"
+                <controls:FASettingsExpander.Footer>
+                    <controls:FAToggleSwitch IsChecked="{Binding Config.AutoOpenUsbDriveOnInsert, Mode=TwoWay}"
                                   Checked="AutoOpenUsbToggle_OnChanged"
                                   Unchecked="AutoOpenUsbToggle_OnChanged" />
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>
 
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE97B;}"
+            <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xE97B;}"
                                        Header="自动清理 ClassIsland 内存"
                                        Description="当软件内存占用超过 500MB 时自动执行垃圾回收与工作集修剪。">
-                <controls:SettingsExpander.Footer>
-                    <ToggleSwitch IsChecked="{Binding Config.AutoCleanupClassIslandMemory, Mode=TwoWay}"
+                <controls:FASettingsExpander.Footer>
+                    <controls:FAToggleSwitch IsChecked="{Binding Config.AutoCleanupClassIslandMemory, Mode=TwoWay}"
                                   Checked="AutoCleanupMemoryToggle_OnChanged"
                                   Unchecked="AutoCleanupMemoryToggle_OnChanged" />
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>
 
         </StackPanel>
     </ScrollViewer>

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia.Controls;
 using Avalonia.Interactivity;
 using FluentAvalonia.UI.Controls;
 using ClassIsland.Core.Abstractions.Controls;
@@ -32,7 +33,7 @@ public partial class MoreFeaturesOptionsSettingsPage : SettingsPageBase
 
     private void AutoOpenUsbToggle_OnChanged(object? sender, RoutedEventArgs e)
     {
-        if (sender is FAToggleSwitch toggleSwitch)
+        if (sender is ToggleSwitch toggleSwitch)
         {
             Config.AutoOpenUsbDriveOnInsert = toggleSwitch.IsChecked == true;
         }
@@ -44,7 +45,7 @@ public partial class MoreFeaturesOptionsSettingsPage : SettingsPageBase
 
     private void AutoCleanupMemoryToggle_OnChanged(object? sender, RoutedEventArgs e)
     {
-        if (sender is FAToggleSwitch toggleSwitch)
+        if (sender is ToggleSwitch toggleSwitch)
         {
             Config.AutoCleanupClassIslandMemory = toggleSwitch.IsChecked == true;
         }

--- a/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
+++ b/SettingsPage/MoreFeaturesOptionsSettingsPage.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Interactivity;
+using FluentAvalonia.UI.Controls;
 using ClassIsland.Core.Abstractions.Controls;
 using ClassIsland.Core.Attributes;
 using SystemTools.ConfigHandlers;
@@ -31,7 +32,7 @@ public partial class MoreFeaturesOptionsSettingsPage : SettingsPageBase
 
     private void AutoOpenUsbToggle_OnChanged(object? sender, RoutedEventArgs e)
     {
-        if (sender is Avalonia.Controls.ToggleSwitch toggleSwitch)
+        if (sender is FAToggleSwitch toggleSwitch)
         {
             Config.AutoOpenUsbDriveOnInsert = toggleSwitch.IsChecked == true;
         }
@@ -43,7 +44,7 @@ public partial class MoreFeaturesOptionsSettingsPage : SettingsPageBase
 
     private void AutoCleanupMemoryToggle_OnChanged(object? sender, RoutedEventArgs e)
     {
-        if (sender is Avalonia.Controls.ToggleSwitch toggleSwitch)
+        if (sender is FAToggleSwitch toggleSwitch)
         {
             Config.AutoCleanupClassIslandMemory = toggleSwitch.IsChecked == true;
         }

--- a/SettingsPage/SystemToolsSettingsPage.axaml
+++ b/SettingsPage/SystemToolsSettingsPage.axaml
@@ -163,7 +163,7 @@
                     <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal">
                             <controls1:ExperimentalBadge IsVisible="{Binding Settings.IsExperimentalModeActivated}" />
-                            <controls:FAToggleSwitch
+                            <ToggleSwitch
                                 IsChecked="{Binding ViewModel.Settings.EnableExperimentalFeatures, Mode=TwoWay}" />
                         </StackPanel>
                     </controls:FASettingsExpander.Footer>
@@ -190,7 +190,7 @@
                                            Header="启用悬浮窗功能"
                                            Description="关闭后将禁用悬浮窗相关全部功能">
                     <controls:FASettingsExpander.Footer>
-                        <controls:FAToggleSwitch IsChecked="{Binding ViewModel.Settings.EnableFloatingWindowFeature, Mode=TwoWay}"
+                        <ToggleSwitch IsChecked="{Binding ViewModel.Settings.EnableFloatingWindowFeature, Mode=TwoWay}"
                                       Click="OnFloatingFeatureToggleClick" />
                     </controls:FASettingsExpander.Footer>
                 </controls:FASettingsExpander>
@@ -201,7 +201,7 @@
 
                     <controls:FASettingsExpanderItem Content="启用需要添加 FFmpeg 依赖的功能">
                         <controls:FASettingsExpanderItem.Footer>
-                            <controls:FAToggleSwitch IsChecked="{Binding ViewModel.Settings.EnableFfmpegFeatures, Mode=TwoWay}"
+                            <ToggleSwitch IsChecked="{Binding ViewModel.Settings.EnableFfmpegFeatures, Mode=TwoWay}"
                                           Click="OnFfmpegToggleClick" />
                         </controls:FASettingsExpanderItem.Footer>
                     </controls:FASettingsExpanderItem>
@@ -219,7 +219,7 @@
                         <controls:FASettingsExpanderItem.Footer>
                             <StackPanel Orientation="Horizontal">
                                 <controls1:ExperimentalBadge IsVisible="{Binding Settings.IsExperimentalModeActivated}" />
-                                <controls:FAToggleSwitch
+                                <ToggleSwitch
                                     IsChecked="{Binding ViewModel.Settings.EnableFaceRecognition, Mode=TwoWay}"
                                     Click="OnFaceRecognitionToggleClick" />
                             </StackPanel>

--- a/SettingsPage/SystemToolsSettingsPage.axaml
+++ b/SettingsPage/SystemToolsSettingsPage.axaml
@@ -1,4 +1,4 @@
-﻿<ci:SettingsPageBase x:Class="SystemTools.SystemToolsSettingsPage"
+<ci:SettingsPageBase x:Class="SystemTools.SystemToolsSettingsPage"
                      xmlns="https://github.com/avaloniaui"
                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -8,6 +8,7 @@
                      xmlns:systemTools="clr-namespace:SystemTools"
                      xmlns:behavior="clr-namespace:System.Windows.Forms.Design.Behavior;assembly=System.Windows.Forms.Design"
                      xmlns:controls1="clr-namespace:SystemTools.Controls"
+                     x:CompileBindings="False"
                      mc:Ignorable="d"
                      d:DesignHeight="450"
                      d:DesignWidth="800">
@@ -144,95 +145,95 @@
                     <Label VerticalAlignment="Center" FontSize="28">功能 · 主设置</Label>
                 </StackPanel>
 
-                <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE079;}"
+                <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xE079;}"
                                            Header="启用功能选项"
                                            Description="选择需要本插件要启用的功能">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal">
                             <Button Content="管理启用的功能..."
                                     Width="165"
                                     Click="OnManageFeaturesClick" />
                         </StackPanel>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE508;}"
+                <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xE508;}"
                                            Header="实验性功能"
                                            Description="启用后可以使用实验性功能，不保证其稳定性。">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal">
                             <controls1:ExperimentalBadge IsVisible="{Binding Settings.IsExperimentalModeActivated}" />
-                            <ToggleSwitch
+                            <controls:FAToggleSwitch
                                 IsChecked="{Binding ViewModel.Settings.EnableExperimentalFeatures, Mode=TwoWay}" />
                         </StackPanel>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
                 
                 
-                <!--<controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE28E;}"
+                <!--<controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xE28E;}"
                                            Header="更多功能选项……"
                                            Description="在这里启用相对小众的 / 正处于预览阶段的更多功能">
-                    <controls:SettingsExpander.Footer>
+                    <controls:FASettingsExpander.Footer>
                         <Button Content="更多功能选项..."
                                 Width="165"
                                 Click="OnOpenMoreFeaturesClick" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>-->
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>-->
                 
-                <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE28E;}"
+                <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xE28E;}"
                                            Header="更多功能选项……"
                                            Description="在这里启用相对小众的 / 正处于预览阶段的更多功能"
                                            ActionIconSource="{ci:FluentIconSource &#xEC2E;}"
                                            Click="OnOpenMoreFeaturesClick" />
 
-                <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xEA37;}"
+                <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xEA37;}"
                                            Header="启用悬浮窗功能"
                                            Description="关闭后将禁用悬浮窗相关全部功能">
-                    <controls:SettingsExpander.Footer>
-                        <ToggleSwitch IsChecked="{Binding ViewModel.Settings.EnableFloatingWindowFeature, Mode=TwoWay}"
+                    <controls:FASettingsExpander.Footer>
+                        <controls:FAToggleSwitch IsChecked="{Binding ViewModel.Settings.EnableFloatingWindowFeature, Mode=TwoWay}"
                                       Click="OnFloatingFeatureToggleClick" />
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE071;}"
+                <controls:FASettingsExpander IconSource="{ci:FluentIconSource &#xE071;}"
                                            Header="启用扩展功能"
                                            Description="启用需要下载依赖的更多可选功能">
 
-                    <controls:SettingsExpanderItem Content="启用需要添加 FFmpeg 依赖的功能">
-                        <controls:SettingsExpanderItem.Footer>
-                            <ToggleSwitch IsChecked="{Binding ViewModel.Settings.EnableFfmpegFeatures, Mode=TwoWay}"
+                    <controls:FASettingsExpanderItem Content="启用需要添加 FFmpeg 依赖的功能">
+                        <controls:FASettingsExpanderItem.Footer>
+                            <controls:FAToggleSwitch IsChecked="{Binding ViewModel.Settings.EnableFfmpegFeatures, Mode=TwoWay}"
                                           Click="OnFfmpegToggleClick" />
-                        </controls:SettingsExpanderItem.Footer>
-                    </controls:SettingsExpanderItem>
+                        </controls:FASettingsExpanderItem.Footer>
+                    </controls:FASettingsExpanderItem>
 
-                    <controls:SettingsExpanderItem Content="下载插件所需 FFmpeg 依赖">
-                        <controls:SettingsExpanderItem.Footer>
+                    <controls:FASettingsExpanderItem Content="下载插件所需 FFmpeg 依赖">
+                        <controls:FASettingsExpanderItem.Footer>
                             <Button Content="点击下载（190 MB）"
                                     Width="165"
                                     Click="OnDownloadFfmpegClick"
                                     IsEnabled="{Binding ViewModel.IsFfmpegDownloadEnabled}" />
-                        </controls:SettingsExpanderItem.Footer>
-                    </controls:SettingsExpanderItem>
+                        </controls:FASettingsExpanderItem.Footer>
+                    </controls:FASettingsExpanderItem>
 
-                    <controls:SettingsExpanderItem Content="启用人脸识别验证功能">
-                        <controls:SettingsExpanderItem.Footer>
+                    <controls:FASettingsExpanderItem Content="启用人脸识别验证功能">
+                        <controls:FASettingsExpanderItem.Footer>
                             <StackPanel Orientation="Horizontal">
                                 <controls1:ExperimentalBadge IsVisible="{Binding Settings.IsExperimentalModeActivated}" />
-                                <ToggleSwitch
+                                <controls:FAToggleSwitch
                                     IsChecked="{Binding ViewModel.Settings.EnableFaceRecognition, Mode=TwoWay}"
                                     Click="OnFaceRecognitionToggleClick" />
                             </StackPanel>
-                        </controls:SettingsExpanderItem.Footer>
-                    </controls:SettingsExpanderItem>
+                        </controls:FASettingsExpanderItem.Footer>
+                    </controls:FASettingsExpanderItem>
 
-                    <controls:SettingsExpanderItem Content="下载人脸识别验证模型及运行时">
-                        <controls:SettingsExpanderItem.Footer>
+                    <controls:FASettingsExpanderItem Content="下载人脸识别验证模型及运行时">
+                        <controls:FASettingsExpanderItem.Footer>
                             <Button Content="点击下载（138 MB）"
                                     Width="165"
                                     Click="OnDownloadFaceModelsClick"
                                     IsEnabled="{Binding ViewModel.IsFaceModelsDownloadEnabled}" />
-                        </controls:SettingsExpanderItem.Footer>
-                    </controls:SettingsExpanderItem>
+                        </controls:FASettingsExpanderItem.Footer>
+                    </controls:FASettingsExpanderItem>
 
                     <StackPanel IsVisible="{Binding ViewModel.ShowDownloadProgress}"
                                 Margin="12,0,12,12"
@@ -244,7 +245,7 @@
                                      Maximum="100"
                                      Height="4" />
                     </StackPanel>
-                </controls:SettingsExpander>
+                </controls:FASettingsExpander>
 
                 <TextBlock Text="Programmer_Wang ©2026"
                            Foreground="Gray"

--- a/SettingsPage/SystemToolsSettingsPage.axaml.cs
+++ b/SettingsPage/SystemToolsSettingsPage.axaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.ComponentModel;
@@ -81,7 +81,7 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
 
     private async void OnFfmpegToggleClick(object? sender, RoutedEventArgs e)
     {
-        if (sender is not ToggleSwitch toggle) return;
+        if (sender is not FAToggleSwitch toggle) return;
 
         if (toggle.IsChecked == true)
         {
@@ -117,12 +117,12 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
 
     private async Task ShowFfmpegNotFoundDialogAsync()
     {
-        var dialog = new ContentDialog
+        var dialog = new FAContentDialog
         {
             Title = "提示",
             Content = "请您先下载本插件专用的ffmpeg模块！",
             PrimaryButtonText = "确定",
-            DefaultButton = ContentDialogButton.Primary
+            DefaultButton = FAContentDialogButton.Primary
         };
 
         await dialog.ShowAsync();
@@ -130,19 +130,19 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
 
     private async void OnFaceRecognitionToggleClick(object? sender, RoutedEventArgs e)
     {
-        if (sender is not ToggleSwitch toggle) return;
+        if (sender is not FAToggleSwitch toggle) return;
 
         if (toggle.IsChecked == true)
         {
             if (!ViewModel.CheckFaceModelsExists())
             {
                 toggle.IsChecked = false;
-                var dialog = new ContentDialog
+                var dialog = new FAContentDialog
                 {
                     Title = "提示",
                     Content = "请您先下载人脸识别验证模型及运行时依赖！",
                     PrimaryButtonText = "确定",
-                    DefaultButton = ContentDialogButton.Primary
+                    DefaultButton = FAContentDialogButton.Primary
                 };
                 await dialog.ShowAsync();
             }
@@ -180,24 +180,24 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
 
     private async Task ShowErrorDialogAsync()
     {
-        var dialog = new ContentDialog
+        var dialog = new FAContentDialog
         {
             Title = "错误",
             Content = "下载出错，请重试！",
             PrimaryButtonText = "确定",
-            DefaultButton = ContentDialogButton.Primary
+            DefaultButton = FAContentDialogButton.Primary
         };
         await dialog.ShowAsync();
     }
 
     private async Task ShowMd5ErrorDialogAsync()
     {
-        var dialog = new ContentDialog
+        var dialog = new FAContentDialog
         {
             Title = "错误",
             Content = "下载文件MD5校验错误，请重新下载！",
             PrimaryButtonText = "确定",
-            DefaultButton = ContentDialogButton.Primary
+            DefaultButton = FAContentDialogButton.Primary
         };
         await dialog.ShowAsync();
     }
@@ -298,24 +298,24 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
             return;
         }
 
-        var data = new DataObject();
-        data.Set("FloatingTriggerButtonId", buttonId);
+        var data = new DataTransfer();
+        data.SetData("FloatingTriggerButtonId", buttonId);
 
         _floatingDragSourceBorder = null;
         _floatingDragStartPoint = null;
-        await DragDrop.DoDragDrop(e, data, DragDropEffects.Move);
+        await e.DoDragDrop(data, DragDropEffects.Move);
         e.Handled = e.Pointer.Type is PointerType.Touch or PointerType.Pen;
     }
 
     private static bool TryGetDragButtonId(DragEventArgs e, out string buttonId)
     {
         buttonId = string.Empty;
-        if (!e.Data.Contains("FloatingTriggerButtonId"))
+        if (!e.DataTransfer.Contains("FloatingTriggerButtonId"))
         {
             return false;
         }
 
-        buttonId = e.Data.Get("FloatingTriggerButtonId") as string ?? string.Empty;
+        buttonId = e.DataTransfer.Get("FloatingTriggerButtonId") as string ?? string.Empty;
         return !string.IsNullOrWhiteSpace(buttonId);
     }
 

--- a/SettingsPage/SystemToolsSettingsPage.axaml.cs
+++ b/SettingsPage/SystemToolsSettingsPage.axaml.cs
@@ -22,7 +22,7 @@ using ClassIsland.Core.Abstractions.Services;
 namespace SystemTools;
 
 [HidePageTitle]
-[SettingsPageInfo("systemtools.settings.main", "主设置", "\uE079", "\uE078")]
+[SettingsPageInfo("systemtools.settings.main", "主设置", "", "")]
 public partial class SystemToolsSettingsPage : SettingsPageBase
 {
     public SystemToolsSettingsPage()
@@ -81,7 +81,7 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
 
     private async void OnFfmpegToggleClick(object? sender, RoutedEventArgs e)
     {
-        if (sender is not FAToggleSwitch toggle) return;
+        if (sender is not ToggleSwitch toggle) return;
 
         if (toggle.IsChecked == true)
         {
@@ -130,7 +130,7 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
 
     private async void OnFaceRecognitionToggleClick(object? sender, RoutedEventArgs e)
     {
-        if (sender is not FAToggleSwitch toggle) return;
+        if (sender is not ToggleSwitch toggle) return;
 
         if (toggle.IsChecked == true)
         {
@@ -235,6 +235,7 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
 
     private Point? _floatingDragStartPoint;
     private Border? _floatingDragSourceBorder;
+    private PointerPressedEventArgs? _floatingDragPressedArgs;
 
     private void OnAddFloatingTriggerRowClick(object? sender, RoutedEventArgs e)
     {
@@ -266,6 +267,7 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
 
         _floatingDragSourceBorder = border;
         _floatingDragStartPoint = e.GetPosition(border);
+        _floatingDragPressedArgs = e;
         e.Handled = e.Pointer.Type is PointerType.Touch or PointerType.Pen;
     }
 
@@ -273,6 +275,7 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
     {
         _floatingDragSourceBorder = null;
         _floatingDragStartPoint = null;
+        _floatingDragPressedArgs = null;
     }
 
     private async void OnFloatingTriggerItemPointerMoved(object? sender, PointerEventArgs e)
@@ -298,24 +301,29 @@ public partial class SystemToolsSettingsPage : SettingsPageBase
             return;
         }
 
+        if (_floatingDragPressedArgs == null)
+        {
+            return;
+        }
+
         var data = new DataTransfer();
-        data.SetData("FloatingTriggerButtonId", buttonId);
+        var format = DataFormat.CreateStringApplicationFormat("FloatingTriggerButtonId");
+        data.Add(DataTransferItem.Create(format, buttonId));
 
         _floatingDragSourceBorder = null;
         _floatingDragStartPoint = null;
-        await e.DoDragDrop(data, DragDropEffects.Move);
+        await DragDrop.DoDragDropAsync(_floatingDragPressedArgs, data, DragDropEffects.Move);
+        _floatingDragPressedArgs = null;
         e.Handled = e.Pointer.Type is PointerType.Touch or PointerType.Pen;
     }
 
     private static bool TryGetDragButtonId(DragEventArgs e, out string buttonId)
     {
         buttonId = string.Empty;
-        if (!e.DataTransfer.Contains("FloatingTriggerButtonId"))
-        {
+        var format = DataFormat.CreateStringApplicationFormat("FloatingTriggerButtonId");
+        if (!e.DataTransfer.Formats.Contains(format))
             return false;
-        }
-
-        buttonId = e.DataTransfer.Get("FloatingTriggerButtonId") as string ?? string.Empty;
+        buttonId = e.DataTransfer.TryGetText() ?? string.Empty;
         return !string.IsNullOrWhiteSpace(buttonId);
     }
 

--- a/SystemTools.csproj
+++ b/SystemTools.csproj
@@ -4,9 +4,6 @@
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <UseWindowsForms>true</UseWindowsForms>
-        <EnableDynamicLoading>true</EnableDynamicLoading>
-        <CreateCipx>true</CreateCipx>
-        <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
         <Platforms>x64</Platforms>
     </PropertyGroup>
     <ItemGroup>
@@ -14,12 +11,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="ClassIsland.PluginSdk" Version="2.1.1">
-            <ExcludeAssets>runtime; native</ExcludeAssets>
-        </PackageReference>
-        <PackageReference Include="ClassIsland.Core" Version="2.1.1">
-            <ExcludeAssets>runtime; native</ExcludeAssets>
-        </PackageReference>
+        <PackageReference Include="ClassIsland.PluginSdk" Version="2.1.1.0" />
         <PackageReference Include="DlibDotNet" Version="19.21.0.20220724" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">

--- a/SystemTools.csproj
+++ b/SystemTools.csproj
@@ -6,6 +6,7 @@
         <UseWindowsForms>true</UseWindowsForms>
         <EnableDynamicLoading>true</EnableDynamicLoading>
         <CreateCipx>true</CreateCipx>
+        <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
         <Platforms>x64</Platforms>
     </PropertyGroup>
     <ItemGroup>

--- a/SystemTools.csproj
+++ b/SystemTools.csproj
@@ -13,16 +13,16 @@
     <ItemGroup>
         <PackageReference Include="ClassIsland.PluginSdk" Version="2.1.1.0" />
         <PackageReference Include="DlibDotNet" Version="19.21.0.20220724" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="OpenCvSharp4" Version="4.9.0.20240103" />
         <PackageReference Include="OpenCvSharp4.Extensions" Version="4.5.3.20211225" />
         <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.9.0.20240103" />
-        <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
-        <PackageReference Include="System.Management" Version="11.0.0-preview.1.26104.118" />
+        <PackageReference Include="System.Drawing.Common" Version="10.0.10" />
+        <PackageReference Include="System.Management" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/SystemTools.csproj
+++ b/SystemTools.csproj
@@ -1,9 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+        <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <UseWindowsForms>true</UseWindowsForms>
+        <EnableDynamicLoading>true</EnableDynamicLoading>
+        <CreateCipx>true</CreateCipx>
         <Platforms>x64</Platforms>
     </PropertyGroup>
     <ItemGroup>
@@ -11,10 +13,14 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="ClassIsland.PluginSDK" Version="2.0.0.1" />
-        <PackageReference Include="ClassIsland.Core" Version="2.0.0.1" />
+        <PackageReference Include="ClassIsland.PluginSdk" Version="2.1.1">
+            <ExcludeAssets>runtime; native</ExcludeAssets>
+        </PackageReference>
+        <PackageReference Include="ClassIsland.Core" Version="2.1.1">
+            <ExcludeAssets>runtime; native</ExcludeAssets>
+        </PackageReference>
         <PackageReference Include="DlibDotNet" Version="19.21.0.20220724" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -22,7 +28,7 @@
         <PackageReference Include="OpenCvSharp4" Version="4.9.0.20240103" />
         <PackageReference Include="OpenCvSharp4.Extensions" Version="4.5.3.20211225" />
         <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.9.0.20240103" />
-        <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+        <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
         <PackageReference Include="System.Management" Version="11.0.0-preview.1.26104.118" />
     </ItemGroup>
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,7 @@ description: 提供多彩而丰富的更多 组件/行动/触发器/实用工具
 entranceAssembly: "SystemTools.dll"
 url: https://github.com/Programmer-MrWang/SystemTools
 version: 2.5.1.101
-apiVersion: 2.0.0.0
+apiVersion: 2.2
 author: Programmer-MrWang
 readme: README.md
 icon: icon.png

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,8 +8,8 @@ name: SystemTools
 description: 提供多彩而丰富的更多 组件/行动/触发器/实用工具
 entranceAssembly: "SystemTools.dll"
 url: https://github.com/Programmer-MrWang/SystemTools
-version: 2.5.1.101
-apiVersion: 2.2
+version: 2.5.1.102
+apiVersion: 2.2.0.0
 author: Programmer-MrWang
 readme: README.md
 icon: icon.png


### PR DESCRIPTION
### Motivation
- 目标是适配 ClassIsland `develop/v2/misha-alpha` 分支的变更：迁移到 Avalonia 12 / FluentAvalonia 3、移除已弃用的 Avalonia API、将目标框架切换到 .NET 10，并更新插件清单的 `apiVersion` 到 `2.2`。
- 这些平台/包变更会影响插件的构建和运行时绑定代码，需要在插件中替换不再可用的旧写法以确保兼容性。

### Description
- 更新 `SystemTools.csproj` 以将目标框架改为 `net10.0-windows10.0.19041.0`，并加入 `<EnableDynamicLoading>true</EnableDynamicLoading>` 与 `<CreateCipx>true</CreateCipx>` 属性，同时将 `ClassIsland.PluginSdk` 与 `ClassIsland.Core` 更新为 `2.1.1` 并用 `<ExcludeAssets>runtime; native</ExcludeAssets>` 排除宿主应提供的运行时/本地资产；并将 `Microsoft.Extensions.DependencyInjection` 与 `System.Drawing.Common` 升级到 `10.0.0`。 (文件：`SystemTools.csproj`)
- 替换旧的 Avalonia 绑定写法：把索引器绑定 `_control[!Property] = new Binding(...)` 改为 `_control.Bind(Property, new Binding(...))`，并移除对 `ToBinding()` 的调用（直接使用 `GetObservable(...)`），以兼容 Avalonia 12。受影响的控件文件包括：`Controls/AdjustScreenBrightnessSettingsControl.cs`、`Controls/DisableDeviceSettingsControl.cs`、`Controls/EnableDeviceSettingsControl.cs`、`Controls/HotkeyRecorderControl.cs`、`Controls/KillProcessSettingsControl.cs`、`Controls/SetVolumeSettingsControl.cs`、`Controls/ShowFloatingWindowSettingsControl.cs`、`Controls/ShowToastSettingsControl.cs`、`Controls/TriggerCustomTriggerSettingsControl.cs`、`Controls/TypeContentSettingsControl.cs`。
- 更新插件清单 `manifest.yml` 的 `apiVersion` 为 `2.2`。 (文件：`manifest.yml`)
- 删除因兼容性不再需要的 `using static System.Windows.Forms.VisualStyles.VisualStyleElement.TrayNotify;` 等多余引用以简化代码。 (示例：`Controls/HotkeyRecorderControl.cs`)

### Testing
- 对 `SystemTools.csproj` 运行了 XML 解析检查：使用 `python3` 的 `xml.etree.ElementTree.parse('SystemTools.csproj')`，解析通过（成功）。
- 用 `rg` / 脚本扫描并确认已移除索引器绑定语法 `\[!.*Property\]` 与 `ToBinding()` 的调用（扫描成功，未发现残留样式）。
- 尝试运行 `dotnet build SystemTools.csproj` 进行实际编译时环境中未安装 `dotnet`，因此真实构建未执行（构建步骤被跳过）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5edd728fd0832aa98027aeaea3c3ad)