### PR TITLE
Adjust package references and prevent DI assembly conflicts in SystemTools.csproj

### DIFF
--- a/SystemTools.csproj
+++ b/SystemTools.csproj
@@ -17,11 +17,18 @@
         <PackageReference Include="ClassIsland.PluginSdk" Version="2.1.1">
             <ExcludeAssets>runtime; native</ExcludeAssets>
         </PackageReference>
-        <PackageReference Include="ClassIsland.Core" Version="2.1.1">
+        <PackageReference Include="DlibDotNet" Version="19.21.0.20220724" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0">
+            <!--
+              ClassIsland's PluginLoadContext resolves assemblies from the plugin directory before
+              falling back to the host. Do not copy Microsoft.Extensions.* into the plugin package:
+              PluginBase.Initialize is declared by the host with the host's IServiceCollection type,
+              and a plugin-local copy of Microsoft.Extensions.DependencyInjection.Abstractions gives
+              SystemTools.Plugin.Initialize a different parameter type identity, causing
+              TypeLoadException while PluginService enumerates ExportedTypes.
+            -->
             <ExcludeAssets>runtime; native</ExcludeAssets>
         </PackageReference>
-        <PackageReference Include="DlibDotNet" Version="19.21.0.20220724" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Motivation
- Prevent plugin/host `Microsoft.Extensions` type identity conflicts by not copying DI runtime into the plugin and align the DI package version with the host, and tidy project package references.

### Description
- Removed the `ClassIsland.Core` package reference and reordered package references in `SystemTools.csproj`.
- Added `DlibDotNet` as an explicit package reference earlier in the file.
- Downgraded `Microsoft.Extensions.DependencyInjection` to `8.0.0` and added `<ExcludeAssets>runtime; native</ExcludeAssets>` with an explanatory comment to avoid shipping a plugin-local copy that would cause `TypeLoadException` when the host and plugin have different `Microsoft.Extensions` assembly identities.
- Normalized file ending by ensuring a newline at EOF.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eee5bed40832abcf38df92a289279)