### PR TITLE
fix: distinguish OS shutdown from ClassIsland exit

### DIFF
--- a/Actions/AdvancedShutdownAction.cs
+++ b/Actions/AdvancedShutdownAction.cs
@@ -38,7 +38,8 @@ public class AdvancedShutdownAction(ILogger<AdvancedShutdownAction> logger) : Ac
     public static void CancelPlanOnAppStopping()
     {
         StopCountdownProcess();
-        TryAbortSystemShutdown();
+        // AppStopping is also raised during OS shutdown. Do not run `shutdown /a`
+        // here: it can abort the real shutdown and starts shutdown.exe during teardown.
     }
 
     protected override async Task OnInvoke()

--- a/Actions/AdvancedShutdownAction.cs
+++ b/Actions/AdvancedShutdownAction.cs
@@ -7,6 +7,7 @@ using ClassIsland.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
@@ -34,12 +35,22 @@ public class AdvancedShutdownAction(ILogger<AdvancedShutdownAction> logger) : Ac
     private static DispatcherTimer? _watchdogTimer;
     private static bool _allowMainDialogClose;
     private static bool _allowFloatingWindowClose;
+    private static int _appStoppingHandled;
 
-    public static void CancelPlanOnAppStopping()
+    public static bool CancelPlanOnAppStopping(bool isSessionEnding)
     {
         StopCountdownProcess();
-        // AppStopping is also raised during OS shutdown. Do not run `shutdown /a`
-        // here: it can abort the real shutdown and starts shutdown.exe during teardown.
+        if (Interlocked.Exchange(ref _appStoppingHandled, 1) != 0)
+        {
+            return false;
+        }
+
+        if (!isSessionEnding)
+        {
+            TryAbortSystemShutdown();
+        }
+
+        return true;
     }
 
     protected override async Task OnInvoke()

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -94,6 +94,7 @@ public partial class Plugin : PluginBase
         services.AddSingleton<UsbAutoPlayService>();
         services.AddSingleton<ClassIslandMemoryAutoCleanupService>();
         services.AddSingleton<SystemMemoryCleanupService>();
+        services.AddSingleton<SystemShutdownMonitor>();
         services.AddSingleton<MainWindowClickService>();
         services.AddSingleton<IOpenAiCompatibleService, OpenAiCompatibleService>();
         if (GlobalConstants.MainConfig?.Data.EnableAiService == true)
@@ -169,6 +170,7 @@ public partial class Plugin : PluginBase
 
         AppBase.Current.AppStarted += (o, args) =>
         {
+            IAppHost.GetService<SystemShutdownMonitor>().Start();
             // 迁移旧版悬浮窗配置到文件存储
             IAppHost.GetService<ThemeBannerCacheService>().Start();
             IAppHost.GetService<AboutTitleImageCacheService>().Start();
@@ -997,13 +999,24 @@ public partial class Plugin : PluginBase
 
     private void OnAppStopping(object? sender, EventArgs e)
     {
+        var systemShutdownMonitor = IAppHost.GetService<SystemShutdownMonitor>();
+        var isSessionEnding = systemShutdownMonitor.IsSessionEnding;
         IAppHost.GetService<AdaptiveThemeSyncService>().Stop();
         IAppHost.TryGetService<AiVoiceConversationService>()?.Dispose();
         IAppHost.GetService<MainWindowTextOcclusionService>().Shutdown(restoreMainWindow: true);
         IAppHost.GetService<UsbAutoPlayService>().Stop();
         IAppHost.GetService<ClassIslandMemoryAutoCleanupService>().Stop();
         IAppHost.GetService<SystemMemoryCleanupService>().Stop();
-        AdvancedShutdownAction.CancelPlanOnAppStopping();
+        var appStoppingHandled = AdvancedShutdownAction.CancelPlanOnAppStopping(isSessionEnding);
+        if (appStoppingHandled && isSessionEnding)
+        {
+            _logger?.LogInformation("[SystemTools]检测到系统关机或注销，跳过 shutdown /a。");
+        }
+        else if (appStoppingHandled)
+        {
+            _logger?.LogInformation("[SystemTools]检测到 ClassIsland 主动退出，尝试执行一次 shutdown /a。");
+        }
+        systemShutdownMonitor.Dispose();
         IAppHost.TryGetService<AiChatWindowService>()?.Close();
         IAppHost.TryGetService<VoskSpeechService>()?.Dispose();
         IAppHost.TryGetService<KeywordSpeechService>()?.Dispose();

--- a/Services/SystemShutdownMonitor.cs
+++ b/Services/SystemShutdownMonitor.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace SystemTools.Services;
+
+public sealed class SystemShutdownMonitor : NativeWindow, IDisposable
+{
+    private const int WmQueryEndSession = 0x0011;
+    private const int WmEndSession = 0x0016;
+
+    internal const string WindowCaption = "SystemTools.SystemShutdownMonitor";
+
+    private int _isSessionEnding;
+    private int _isStarted;
+
+    public bool IsSessionEnding => Volatile.Read(ref _isSessionEnding) != 0;
+
+    public void Start()
+    {
+        if (Interlocked.Exchange(ref _isStarted, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            CreateHandle(new CreateParams
+            {
+                Caption = WindowCaption
+            });
+        }
+        catch
+        {
+            Volatile.Write(ref _isStarted, 0);
+            throw;
+        }
+    }
+
+    protected override void WndProc(ref Message m)
+    {
+        switch (m.Msg)
+        {
+            case WmQueryEndSession:
+                Volatile.Write(ref _isSessionEnding, 1);
+                break;
+            case WmEndSession:
+                Volatile.Write(ref _isSessionEnding, m.WParam != IntPtr.Zero ? 1 : 0);
+                break;
+        }
+
+        base.WndProc(ref m);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _isStarted, 0) == 0)
+        {
+            return;
+        }
+
+        DestroyHandle();
+    }
+}


### PR DESCRIPTION
## Summary
- add an independent hidden native window that tracks `WM_QUERYENDSESSION` / `WM_ENDSESSION`
- skip `shutdown /a` when Windows is shutting down or logging off
- keep the existing cleanup behavior for a normal ClassIsland exit and run `shutdown /a` exactly once
- deduplicate the branch because ClassIsland 2.1 raises `AppStopping` twice

## Root cause
`AppStopping` is raised both for a normal ClassIsland exit and during OS shutdown. The previous implementation could not distinguish the two and unconditionally launched `shutdown.exe /a`, which could interfere with the real shutdown and matched the observed `shutdown.exe` error popup.

## Implementation
- `SystemShutdownMonitor` owns a hidden Win32 window and records session-ending state before plugin teardown.
- `CancelPlanOnAppStopping(bool isSessionEnding)` always stops the plugin-owned countdown process.
- The method skips `/a` for a system session end; otherwise it invokes `/a` once.
- An `Interlocked` guard makes the full branch idempotent across duplicate `AppStopping` callbacks.

## Validation
- `dotnet build SystemTools.csproj --no-restore` on the PR branch: 0 errors, 26 existing warnings.
- Built the equivalent patch from tag `2.5.1.0` (API 2.0) and installed it into ClassIsland `2.1.0.1` for compatibility testing.
- Startup: plugin loaded successfully and the `SystemTools.SystemShutdownMonitor` window was present in the ClassIsland process.
- Normal tray exit through ClassIsland's own `Stop()` path: ClassIsland exited, exactly one `shutdown.exe` PID was observed, the normal-exit branch was logged once, and there were no Critical entries.
- Simulated session end, scoped only to ClassIsland windows: `WM_QUERYENDSESSION` returned `TRUE`; after session-ending state was set, ClassIsland's `Stop()` path exited with zero `shutdown.exe` processes, the skip branch was logged once, and there were no Critical entries.
- No real shutdown was initiated or broadcast during the test.
- `git diff --check` passed.